### PR TITLE
Fixed URL handling for extracting origin

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -216,7 +216,7 @@ function installManifestUrl(manifestUrl) {
 }
 
 function installManifest(manifestUrl, webapp, installOrigin) {
-  let origin = manifestUrl.toString().replace(/([^\/])\/[^\/].*/, "$1");
+  let origin = manifestUrl.toString().substring(0, manifestUrl.toString().lastIndexOf(manifestUrl.path));
   if (!installOrigin) {
     installOrigin = origin
   }
@@ -283,7 +283,7 @@ ContextMenu.Item({
                  '  self.postMessage(node.href)' +
                  '});',
   onMessage: function (manifestUrl) {
-    installManifestUrl(manifestUrl);
+    installManifestUrl(URL.URL(manifestUrl));
   }
 });
 


### PR DESCRIPTION
Install from Manifest was merged without my fix to a review comment, using URL for extracting the origin.
