### PR TITLE
Connection to debug with Firefox Remote debugger?

### DIFF
--- a/prosthesis/defaults/preferences/prefs.js
+++ b/prosthesis/defaults/preferences/prefs.js
@@ -1,2 +1,4 @@
 user_pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0");
 user_pref("power.screen.timeout", 86400);
+user_pref("devtools.debugger.remote-enabled", true);
+user_pref("devtools.debugger.remote-port", 4242);


### PR DESCRIPTION
I found one thing that's harder in the simulator than in other emulators of Firefox OS, debugging. There is one handy tool for it that exists in Nightly/Aurora where you can debug a remote device but it needs ip-address and port for connection to the machine.

I've added devtools.debugger.remote-enabled and devtools.debugger.remote-port to enable remote debugging on port 4242 for easier debugging but not entirely sure that it's enough. 
