### PR TITLE
disable the Gaia firstrun experience by overriding the ftu.manifestURL setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build: profile prosthesis b2g
 profile:
 	make -C gaia
 	$(DISABLE_OOP)
+	python ./settings.py
 	rm -rf gaia/profile/startupCache
 	rm -rf addon/template
 	mkdir -p addon/template

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+  "ftu.manifestURL": null
+}

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+# Override default Gaia profile settings with our own values.
+
+import json
+
+settings_file = 'gaia/profile/settings.json'
+override_file = 'settings.json'
+
+with open(settings_file, 'r') as f:
+  settings = json.load(f)
+
+with open(override_file, 'r') as f:
+  overrides = json.load(f)
+
+for key in overrides.keys():
+  settings[key] = overrides[key]
+
+with open(settings_file, 'wb') as f:
+  json.dump(settings, f, indent=0)


### PR DESCRIPTION
Also updates Gaia to the latest stable version (2012-11-14), which has a firstrun experience (hence the need to disable it).
