### PR TITLE
disable the obsolete remote-JS repl on port 9999 so B2G starts on systems that use that port for other things

### DIFF
--- a/prosthesis/defaults/preferences/prefs.js
+++ b/prosthesis/defaults/preferences/prefs.js
@@ -2,3 +2,4 @@ pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Fir
 pref("power.screen.timeout", 86400);
 pref("devtools.debugger.remote-enabled", true);
 pref("marionette.defaultPrefs.enabled", false);
+pref("b2g.remote-js.enabled", false);


### PR DESCRIPTION
B2G starts a listener on port 9999 to be a [temporary poor man's remote web console](http://mxr.mozilla.org/mozilla-central/source/b2g/app/b2g.js#417). But we now have a real remote web console, which makes the feature obsolete. So B2G should remove its temporary one. Until then, this change disables it for the Simulator.

Fixes issue #131.
