### PR TITLE
make remote tools work more consistently

### DIFF
--- a/build/override-settings.json
+++ b/build/override-settings.json
@@ -1,3 +1,6 @@
 {
+  "set": {
+    "debug.oop.disabled": true
+  },
   "remove": ["ftu.manifestURL"]
 }

--- a/build/override-settings.py
+++ b/build/override-settings.py
@@ -14,15 +14,21 @@ with open(settings_file, 'r') as f:
 with open(override_file, 'r') as f:
   overrides = json.load(f)
 
+for key in overrides['set'].keys():
+  settings[key] = overrides['set'][key]
+
 for key in overrides['remove']:
   if key in settings:
     del settings[key]
 
-# Disable OOP on Windows and Linux to work around repaint problems (bug 799768).
-# On Windows, disabling OOP also worked around a B2G startup crash (bug 795484),
-# although it doesn't appear to be necessary anymore.
-if sys.platform == 'win32' or sys.platform.startswith('linux'):
-  settings['debug.oop.disabled'] = True
-
 with open(settings_file, 'wb') as f:
   json.dump(settings, f, indent=2)
+
+# Comments about the overridden settings in override-settings.json, since JSON
+# can't contain comments:
+
+# debug.oop.disabled:
+# Disable OOP to enable use of the remote debugger.
+# Also disable it on Windows/Linux to work around repaint problems (bug 799768).
+# On Windows, disabling OOP also worked around a B2G startup crash (bug 795484),
+# although it doesn't appear to be necessary anymore.

--- a/prosthesis/defaults/preferences/prefs.js
+++ b/prosthesis/defaults/preferences/prefs.js
@@ -1,5 +1,16 @@
-pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0");
-pref("power.screen.timeout", 86400);
-pref("devtools.debugger.remote-enabled", true);
-pref("marionette.defaultPrefs.enabled", false);
-pref("b2g.remote-js.enabled", false);
+// B2G Desktop's UA string doesn't include "Mobile", which various sites sniff
+// to determine if the device in question is a mobile device, which is how
+// we want them to think of the Simulator, so we override the string with one
+// that includes the word.
+//
+// Note that we need to update this string each time we update the version
+// of B2G we ship to one on a different train (i.e. with a different major
+// version number).
+user_pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0");
+
+// Don't go to sleep so quickly.
+user_pref("power.screen.timeout", 86400);
+
+// Enable remote debugging and other tools.
+user_pref("devtools.debugger.remote-enabled", true);
+user_pref("marionette.defaultPrefs.enabled", false);


### PR DESCRIPTION
Two changes are needed:
1. `pref` -> `user_pref` when setting preferences related to remote tools, as the former doesn't override existing preferences that have default values (specifically, _devtools.debugger.remote-enabled_ and _marionette.defaultPrefs.enabled_). I also made this change for the other prefs we set (_general.useragent.override_ and _power.screen.timeout_), so they should start working more consistently too. And I removed _b2g.remote-js.enabled_, which doesn't matter now that the repl it controls has been removed from Gaia.
2. Disable OOP for Mac in addition to Windows and Linux. The remote debugger doesn't yet handle OOP apps, so you can't use it to debug those apps. OOP was already disabled on Windows and Linux for other reasons. Now it's disabled on Mac too for this one.
