### PR TITLE
Feature desktop permissions

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -1039,3 +1039,69 @@ function archiveDir(zipFile, dirToArchive) {
 
   console.log("archived dir " + dirToArchive);
 }
+
+
+
+
+// FIXME: Hack
+
+let PermissionsInstaller = Cu.import("resource://gre/modules/PermissionsInstaller.jsm").PermissionsInstaller;
+
+let PermissionSettings = Cu.import("resource://gre/modules/PermissionSettings.jsm");
+let ManifestHelper = Cu.import("resource://gre/modules/AppsUtils.jsm").ManifestHelper;
+
+function CustomAddPermission(aData, aCallbacks) {
+  setTimeout(function() {
+    console.log("addPermission CALLED");
+    console.log(JSON.stringify(aData));
+  }, 10);
+}
+function CustomGetPermission(aPermission, aManifestURL, aOrigin, aBrowserFlag) {
+  setTimeout(function() {
+    console.log("getPermission: " + aPermission + ", " + aManifestURL + ", " + aOrigin);
+  });
+}
+
+PermissionSettings.addPermissionOld = PermissionSettings.addPermission;
+PermissionSettings.addPermission = CustomAddPermission;
+PermissionSettings.getPermissionOld = PermissionSettings.getPermission;
+PermissionSettings.getPermission = CustomGetPermission;
+PermissionSettings.OVERRIDDEN = true;
+
+console.log(PermissionSettings.OVERRIDDEN);
+console.log(PermissionSettings.addPermission);
+
+let manifest = {
+  "version": "1.0",
+  "name": "Rigid Balls Demo",
+  "description": "Let em bounce!",
+  "launch_path": "/sputflik/examples/rigid-device/index.html",
+  "icons": {
+    "256": "http://icons.iconarchive.com/icons/deleket/puck/256/Mozilla-Firefox-icon.png"
+  },
+  "developer": {
+    "name": "Harald Kirschner",
+    "url": "http://www.harald.me"
+  },
+  "type": "privileged",
+  "permissions": {
+    "systemXHR": {},
+    "settings":{ "access": "readonly" }
+  }
+};
+let origin = "http://localhost";
+
+// let helper = new ManifestHelper(manifest, origin);
+// console.log(JSON.stringify(helper.permissions));
+// console.log(helper.fullLaunchPath());
+
+PermissionsInstaller.installPermissions({
+    manifest: manifest,
+    manifestURL: "http://localhost/sputflik/examples/rigid-device/manifest.webapp",
+    origin: origin
+  },
+  true,
+  function() {
+    console.log("Installation FAILED");
+  }
+);

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -261,12 +261,6 @@ let simulator = {
     );
   },
 
-  overridePermissionSettings: function(argument) {
-    console.log("overridePermissionSettings");
-    this.didOverridePermissionSettings = true;
-
-  },
-
   removeApp: function(id) {
     let apps = simulator.apps;
     let config = apps[id];
@@ -1087,62 +1081,51 @@ XPCOMUtils.defineLazyServiceGetter(this,
                                    "nsIAppsService");
 
 PermissionSettings.addPermission = function CustomAddPermission(aData, aCallbacks) {
-  console.log("PermissionSettings.addPermission CALLED");
-  try {
-    console.log(JSON.stringify(aData));
+  console.log("PermissionSettings.addPermission " + aData.origin);
 
-    let uri = Services.io.newURI(aData.origin, null, null);
+  let uri = Services.io.newURI(aData.origin, null, null);
 
-    console.log("Testing value: " + aData.value);
-
-    let action;
-    switch (aData.value)
-    {
-      case "unknown":
-        action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
-        break;
-      case "allow":
-        action = Ci.nsIPermissionManager.ALLOW_ACTION;
-        break;
-      case "deny":
-        action = Ci.nsIPermissionManager.DENY_ACTION;
-        break;
-      case "prompt":
-        action = Ci.nsIPermissionManager.PROMPT_ACTION;
-        break;
-      default:
-        dump("Unsupported PermisionSettings Action: " + aData.value +"\n");
-        action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
-    }
-    console.log("PermissionSettings.addPermission add: " + aData.origin + " " + action);
-
-    console.log(permissionManager);
-    permissionManager.add(uri, aData.type, action);
-  } catch (e) {
-    console.log(e);
+  let action;
+  switch (aData.value)
+  {
+    case "unknown":
+      action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
+      break;
+    case "allow":
+      action = Ci.nsIPermissionManager.ALLOW_ACTION;
+      break;
+    case "deny":
+      action = Ci.nsIPermissionManager.DENY_ACTION;
+      break;
+    case "prompt":
+      action = Ci.nsIPermissionManager.PROMPT_ACTION;
+      break;
+    default:
+      dump("Unsupported PermisionSettings Action: " + aData.value +"\n");
+      action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
   }
+  console.log("PermissionSettings.addPermission add: " + aData.origin + " " + action);
+
+  permissionManager.add(uri, aData.type, action);
 };
 
 PermissionSettings.getPermission = function CustomGetPermission(aPermission, aManifestURL, aOrigin, aBrowserFlag) {
   console.log("getPermission: " + aPermName + ", " + aManifestURL + ", " + aOrigin);
-  try {
-    let uri = Services.io.newURI(aOrigin, null, null);
-    let result = permissionManager.testExactPermission(uri, aPermName);
 
-    switch (result) {
-      case Ci.nsIPermissionManager.UNKNOWN_ACTION:
-        return "unknown";
-      case Ci.nsIPermissionManager.ALLOW_ACTION:
-        return "allow";
-      case Ci.nsIPermissionManager.DENY_ACTION:
-        return "deny";
-      case Ci.nsIPermissionManager.PROMPT_ACTION:
-        return "prompt";
-      default:
-        dump("Unsupported PermissionSettings Action!\n");
-        return "unknown";
-    }
-  } catch (e) {
-    console.log(e);
+  let uri = Services.io.newURI(aOrigin, null, null);
+  let result = permissionManager.testExactPermission(uri, aPermName);
+
+  switch (result) {
+    case Ci.nsIPermissionManager.UNKNOWN_ACTION:
+      return "unknown";
+    case Ci.nsIPermissionManager.ALLOW_ACTION:
+      return "allow";
+    case Ci.nsIPermissionManager.DENY_ACTION:
+      return "deny";
+    case Ci.nsIPermissionManager.PROMPT_ACTION:
+      return "prompt";
+    default:
+      dump("Unsupported PermissionSettings Action!\n");
+      return "unknown";
   }
 };


### PR DESCRIPTION
## Problem

Firefox Desktop provides the best developer tools. Privileged APIs can't be accessed, so developers have to test on mobile devices at one point, where tools are limited by remote-capability.
Developers need to be able to test privileged APIs using Desktop Firefox.
## Customers

Gaia and FxOS developers
## Solution

Adding an app in Firefox OS Simulator installs the app in B2G Desktop and additionally adds the correct permissions to Firefox (P1).
The app installed in B2G Desktop should also get the requested APIs (P2).
## Implementation

**For Desktop**: Override _PermissionSettings_ [3](http://mxr.mozilla.org/mozilla-central/source/dom/permission/PermissionSettings.jsm) in FxOS Simulator, so _PermissionsInstaller.installPermissions_ [1](http://mxr.mozilla.org/mozilla-central/source/dom/apps/src/PermissionsInstaller.jsm) calls our _PermissionSettings.addPermission_, which will call _nsIPermissionManager.add_ [4](http://mxr.mozilla.org/mozilla-central/source/netwerk/base/public/nsIPermissionManager.idl) instead of _~.addFromPrincipal_.
**For Simulator**: Use Webapps API [2](http://mxr.mozilla.org/mozilla-central/source/dom/apps/src/Webapps.jsm#1196) from the _shell.js_ (command line or reading to files read on B2G Desktop launch)

References:

From https://etherpad.mozilla.org/fxoss-desktop-permissions

cc @fabricedesre, @myk
