### PR TITLE
update addon-sdk submodule to 1.12 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ profile:
 	rm -rf addon/template
 	mkdir -p addon/template
 	mv gaia/profile addon/template/
-	cp addon-sdk/python-lib/cuddlefish/app-extension/bootstrap.js addon/template/
-	cp addon-sdk/python-lib/cuddlefish/app-extension/install.rdf addon/template/
+	cp addon-sdk/app-extension/bootstrap.js addon/template/
+	cp addon-sdk/app-extension/install.rdf addon/template/
 
 prosthesis: profile
 	mkdir -p addon/template/profile/extensions

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -21,6 +21,9 @@ const Gcli = require('gcli');
 const { rootURI } = require('@loader/options');
 const profileURL = rootURI + "profile/";
 
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+
 require("addon-page");
 
 let simulator = {
@@ -176,7 +179,7 @@ let simulator = {
       default:
         webappEntry.manifestURL = id;
     }
-    console.log("Creating webapp entry: " + JSON.stringify(webappEntry, null, 2))
+    console.log("Creating webapp entry: " + JSON.stringify(webappEntry, null, 2));
 
     // Create the webapp record and write it to the registry.
     webapps[config.xkey] = webappEntry;
@@ -220,6 +223,32 @@ let simulator = {
             run();
           }
         } else {
+          // Hosted App
+
+          let PermissionsInstaller;
+          try {
+            PermissionsInstaller =
+              Cu.import("resource://gre/modules/PermissionsInstaller.jsm").
+              PermissionsInstaller;
+          } catch(e) {
+            // PermissionsInstaller doesn't exist on Firefox 17 (and 18/19?),
+            // so catch and ignore an exception importing it.
+          }
+
+          if (PermissionsInstaller) {
+            PermissionsInstaller.installPermissions(
+              {
+                manifest: config.manifest,
+                manifestURL: id,
+                origin: config.origin
+              },
+              false, // isReinstall, installation failed for true
+              function(e) {
+                console.error("PermissionInstaller FAILED for " + config.origin);
+              }
+            );
+          }
+
           let webappFile = File.join(webappDir, "manifest.webapp");
           File.open(webappFile, "w").writeAsync(JSON.stringify(config.manifest, null, 2), function(err) {
             if (err) {
@@ -389,10 +418,10 @@ let simulator = {
           simulator.error("Missing mandatory property (name or description)");
           return;
         }
+
         let contentType = response.headers["Content-Type"];
         if (contentType !== "application/x-web-app-manifest+json") {
-          simulator.error("Unexpected Content-Type: " + contentType + ".");
-          return;
+          console.warn("Unexpected Content-Type: " + contentType + ".");
         }
 
         console.log("Fetched manifest " + JSON.stringify(response.json, null, 2));
@@ -416,7 +445,7 @@ let simulator = {
         } else {
           let contentType = response.headers["Content-Type"];
           if (contentType !== "application/x-web-app-manifest+json") {
-            err = "Unexpected Content-Type " + contentType;
+            console.warn("Unexpected Content-Type " + contentType);
           }
         }
 
@@ -1037,4 +1066,82 @@ function archiveDir(zipFile, dirToArchive) {
   writer.close();
 
   console.log("archived dir " + dirToArchive);
+}
+
+let PermissionSettings;
+try {
+  PermissionSettings =
+    Cu.import("resource://gre/modules/PermissionSettings.jsm").
+    PermissionSettingsModule;
+} catch(e) {
+  // PermissionSettings doesn't exist on Firefox 17 (and 18/19?),
+  // so catch and ignore an exception importing it.
+}
+
+if (PermissionSettings) {
+  PermissionSettings.addPermissionOld = PermissionSettings.addPermission;
+  PermissionSettings.getPermissionOld = PermissionSettings.getPermission;
+
+  XPCOMUtils.defineLazyServiceGetter(this,
+                                     "permissionManager",
+                                     "@mozilla.org/permissionmanager;1",
+                                     "nsIPermissionManager");
+  XPCOMUtils.defineLazyServiceGetter(this,
+                                     "secMan",
+                                     "@mozilla.org/scriptsecuritymanager;1",
+                                     "nsIScriptSecurityManager");
+  XPCOMUtils.defineLazyServiceGetter(this,
+                                     "appsService",
+                                     "@mozilla.org/AppsService;1",
+                                     "nsIAppsService");
+
+  PermissionSettings.addPermission = function CustomAddPermission(aData, aCallbacks) {
+    console.log("PermissionSettings.addPermission " + aData.origin);
+
+    let uri = Services.io.newURI(aData.origin, null, null);
+
+    let action;
+    switch (aData.value)
+    {
+      case "unknown":
+        action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
+        break;
+      case "allow":
+        action = Ci.nsIPermissionManager.ALLOW_ACTION;
+        break;
+      case "deny":
+        action = Ci.nsIPermissionManager.DENY_ACTION;
+        break;
+      case "prompt":
+        action = Ci.nsIPermissionManager.PROMPT_ACTION;
+        break;
+      default:
+        dump("Unsupported PermisionSettings Action: " + aData.value +"\n");
+        action = Ci.nsIPermissionManager.UNKNOWN_ACTION;
+    }
+    console.log("PermissionSettings.addPermission add: " + aData.origin + " " + action);
+
+    permissionManager.add(uri, aData.type, action);
+  };
+
+  PermissionSettings.getPermission = function CustomGetPermission(aPermission, aManifestURL, aOrigin, aBrowserFlag) {
+    console.log("getPermission: " + aPermName + ", " + aManifestURL + ", " + aOrigin);
+
+    let uri = Services.io.newURI(aOrigin, null, null);
+    let result = permissionManager.testExactPermission(uri, aPermName);
+
+    switch (result) {
+      case Ci.nsIPermissionManager.UNKNOWN_ACTION:
+        return "unknown";
+      case Ci.nsIPermissionManager.ALLOW_ACTION:
+        return "allow";
+      case Ci.nsIPermissionManager.DENY_ACTION:
+        return "deny";
+      case Ci.nsIPermissionManager.PROMPT_ACTION:
+        return "prompt";
+      default:
+        dump("Unsupported PermissionSettings Action!\n");
+        return "unknown";
+    }
+  };
 }

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -15,7 +15,7 @@ const ContextMenu = require("context-menu");
 const Request = require('request').Request;
 const Notifications = require("notifications");
 const SStorage = require("simple-storage");
-const WindowUtils = require("sdk/deprecated/window-utils");
+const WindowUtils = require("window/utils");
 const Gcli = require('gcli');
 
 const { rootURI } = require('@loader/options');
@@ -624,7 +624,7 @@ let simulator = {
   },
 
   info: function(msg) {
-    // let window = WindowUtils.activeBrowserWindow;
+    // let window = WindowUtils.getMostRecentBrowserWindow();
     // let nb = window.gBrowser.getNotificationBox();
     // nb.appendNotification(
     //   msg,
@@ -636,7 +636,7 @@ let simulator = {
   },
 
   error: function(msg) {
-    let window = WindowUtils.activeBrowserWindow;
+    let window = WindowUtils.getMostRecentBrowserWindow();
     let nb = window.gBrowser.getNotificationBox();
     nb.appendNotification(
       msg,

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -15,7 +15,7 @@ const ContextMenu = require("context-menu");
 const Request = require('request').Request;
 const Notifications = require("notifications");
 const SStorage = require("simple-storage");
-const WindowUtils = require("api-utils/window-utils");
+const WindowUtils = require("sdk/deprecated/window-utils");
 const Gcli = require('gcli');
 
 const { rootURI } = require('@loader/options');

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -6,7 +6,7 @@ const URL = require("url");
 const Runtime = require("runtime");
 const Tabs = require("tabs");
 const PageMod = require("page-mod").PageMod;
-const UUID = require("api-utils/uuid");
+const UUID = require("sdk/util/uuid");
 const File = require("file");
 const Menuitems = require("menuitems");
 const Prefs = require("preferences-service");
@@ -665,7 +665,6 @@ PageMod({
 //  content: "r2d2b2g",
 //  width: 50,
 //  onClick: function() {
-//    let addontab = require("addon-page");
 //    Tabs.open({
 //      url: Self.data.url("content/index.html"),
 //      onReady: function(tab) {

--- a/addon/package.json
+++ b/addon/package.json
@@ -13,9 +13,7 @@
   ],
   "license": "MPL 2.0",
   "unpack": true,
-  "dependencies": ["addon-kit",
-                   "api-utils",
-                   "gcli",
+  "dependencies": ["gcli",
                    "menuitems",
                    "subprocess",
                    "vold-utils"]

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "id": "r2d2b2g@mozilla.org",
   "name": "r2d2b2g",
-  "version": "1.1pre1dev",
+  "version": "1.1pre2dev",
   "fullName": "Firefox OS Simulator",
   "description": "a Firefox OS simulator",
   "author": "Myk Melez (https://github.com/mykmelez)",

--- a/build/override-settings.json
+++ b/build/override-settings.json
@@ -1,3 +1,6 @@
 {
+  "set": {
+    "debug.oop.disabled": true
+  },
   "remove": ["ftu.manifestURL"]
 }

--- a/build/override-settings.py
+++ b/build/override-settings.py
@@ -14,15 +14,21 @@ with open(settings_file, 'r') as f:
 with open(override_file, 'r') as f:
   overrides = json.load(f)
 
+for key in overrides['set'].keys():
+  settings[key] = overrides['set'][key]
+
 for key in overrides['remove']:
   if key in settings:
     del settings[key]
 
-# Disable OOP on Windows and Linux to work around repaint problems (bug 799768).
-# On Windows, disabling OOP also worked around a B2G startup crash (bug 795484),
-# although it doesn't appear to be necessary anymore.
-if sys.platform == 'win32' or sys.platform.startswith('linux'):
-  settings['debug.oop.disabled'] = True
-
 with open(settings_file, 'wb') as f:
   json.dump(settings, f, indent=2)
+
+# Comments about the overridden settings in override-settings.json, since JSON
+# can't contain comments:
+
+# debug.oop.disabled:
+# Disable OOP to enable use of the remote debugger.
+# Also disable it on Windows/Linux to work around repaint problems (bug 799768).
+# On Windows, disabling OOP also worked around a B2G startup crash (bug 795484),
+# although it doesn't appear to be necessary anymore.

--- a/prosthesis/defaults/preferences/prefs.js
+++ b/prosthesis/defaults/preferences/prefs.js
@@ -1,5 +1,16 @@
-pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0");
-pref("power.screen.timeout", 86400);
-pref("devtools.debugger.remote-enabled", true);
-pref("marionette.defaultPrefs.enabled", false);
-pref("b2g.remote-js.enabled", false);
+// B2G Desktop's UA string doesn't include "Mobile", which various sites sniff
+// to determine if the device in question is a mobile device, which is how
+// we want them to think of the Simulator, so we override the string with one
+// that includes the word.
+//
+// Note that we need to update this string each time we update the version
+// of B2G we ship to one on a different train (i.e. with a different major
+// version number).
+user_pref("general.useragent.override", "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0");
+
+// Don't go to sleep so quickly.
+user_pref("power.screen.timeout", 86400);
+
+// Enable remote debugging and other tools.
+user_pref("devtools.debugger.remote-enabled", true);
+user_pref("marionette.defaultPrefs.enabled", false);


### PR DESCRIPTION
Add-on SDK 1.12 was released today. It isn't urgent for us to update to it, because it doesn't give us any necessary features, and AMO will continue supporting 1.11 for some time.

But the new version makes some changes to the way modules are organized and referenced that pave the way for landing the SDK's modules in Firefox, and I'd rather update to each new version, making a small number of changes each time, than jump several versions when it becomes necessary and have to figure out a large delta of changes.

So here's a branch that makes the necessary (and a few optional) changes to work with the new version of the SDK. Remember to call `git submodule update` after checking out this branch!

@digitarald, does this look good to you?
