### PR TITLE
FIX: install/update app with permissions on b2g instance

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -602,6 +602,8 @@ let simulator = {
       this.defaultApp = null;
     }
 
+    // NOTE: if a b2g instance is already running send request
+    //       or start a new instance and send request on ready
     if (this.isRunning) {
       if (typeof cb === "function")
         cb();
@@ -657,14 +659,10 @@ let simulator = {
                                   isRunning: this.isRunning });
         break;
       case "addAppByDirectory":
-        this.kill(function() {
-          simulator.addAppByDirectory();
-        });
+        simulator.addAppByDirectory();
         break;
       case "addAppByTab":
-        this.kill(function() {
-          simulator.addAppByTabUrl(message.url);
-        });
+        simulator.addAppByTabUrl(message.url);
         break;
       case "listApps":
         if (message.flush) {
@@ -673,9 +671,7 @@ let simulator = {
         this.sendListApps();
         break;
       case "updateApp":
-        this.kill(function() {
-          simulator.updateApp(message.id, true);
-        });
+        simulator.updateApp(message.id, true);
         break;
       case "runApp":
         let appName = this.apps[message.id].name;
@@ -687,9 +683,6 @@ let simulator = {
           });
         };
         cmd = cmd.bind(this);
-
-        // NOTE: if a b2g instance is already running send request
-        //       or start a new instance and send request on ready
         this.run(cmd);
         break;
       case "removeApp":

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -127,12 +127,7 @@ let simulator = {
   },
 
   get tempDir() {
-    let sandbox = {};
-    XPCOMUtils.defineLazyServiceGetter(sandbox, "gDirService",
-                                       "@mozilla.org/file/directory_service;1",
-                                       "nsIProperties");
-
-    let basePath = sandbox.gDirService.get("TmpD", Ci.nsIFile).path;
+    let basePath = Services.dirsvc.get("TmpD", Ci.nsIFile).path;
     return File.join(basePath, "b2g");
   },
 

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -246,24 +246,32 @@ let simulator = {
         );
       }
       
-      let webappFile = File.join(TmpDwebappsDir, "manifest.webapp");
+      let webappFile = File.join(webappDir, "manifest.webapp");
       File.open(webappFile, "w").writeAsync(JSON.stringify(config.manifest, null, 2), function(err) {
         if (err) {
           console.error("Error while writing manifest.webapp " + err);
         }
         console.log("Written manifest.webapp");
-        simulator.info(config.name + " (hosted app) installed in Firefox OS");
+
+        let metadataFile = File.join(webappDir, "metadata.json");
+        let metadata = {
+          origin: config.origin,
+          manifestURL: id,
+        };
+        File.open(metadataFile, "w").writeAsync(JSON.stringify(metadata, null, 2), function(err) {
+          simulator.info(config.name + " (hosted app) installed in Firefox OS");
         
-        // Complete install (Hosted)
-        if (manual) {
-          simulator.defaultApp = null; // id; // DISABLED: because on the first run the app will be not already installed
-          simulator.run(function() {
-            console.log("INSTALLING ",config.xkey);
-            simulator.remoteSimulator.install(config.xkey, null, function(res) {
-              console.debug("INSTALL RESPONSE: ",JSON.stringify(res));
+          // Complete install (Hosted)
+          if (manual) {
+            simulator.defaultApp = null; // id; // DISABLED: because on the first run the app will be not already installed
+            simulator.run(function() {
+              console.log("INSTALLING ",config.xkey);
+              simulator.remoteSimulator.install(config.xkey, null, function(res) {
+                console.debug("INSTALL RESPONSE: ",JSON.stringify(res));
+              });
             });
-          });
-        }
+          }
+        });
       });
     }
     

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -228,11 +228,11 @@ const RemoteSimulatorClient = Class({
 
   // send an install request to the remote webappsActor
   install: function(appId, appType, onResponse) {
-    let remote = this._remote;
-
-    remote.client.request({to: remote.webapps, type: "install", appId: appId,
-                           appType: appType}, 
-                          onResponse);
+    this._remote.client.request({ to: this._remote.webapps,
+                                  type: "install",
+                                  appId: appId,
+                                  appType: appType},
+                                onResponse);
   },
 
   // send a ping request to the remote simulator actor

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -75,7 +75,8 @@ const RemoteSimulatorClient = Class({
           globals: reply,
           tabs: reply.tabs,
           selected: reply.selected,
-          simulator: reply.simulatorActor
+          simulator: reply.simulatorActor,
+          webapps: reply.webappsActor
         });
       }).bind(this));
     });
@@ -222,6 +223,15 @@ const RemoteSimulatorClient = Class({
     let remote = this._remote;
 
     remote.client.request({to: remote.simulator, type: "runApp", appname: appname}, 
+                          onResponse);
+  },
+
+  // send an install request to the remote webappsActor
+  install: function(appId, appType, onResponse) {
+    let remote = this._remote;
+
+    remote.client.request({to: remote.webapps, type: "install", appId: appId,
+                           appType: appType}, 
                           onResponse);
   },
 


### PR DESCRIPTION
This change hooks the new remote webappsActor to install apps into a b2g instance
using mozApps internals, so application permissions will be registered and
correctly available.

This merge should fix: #237
