### PR TITLE
Show connect devtools button or allocated remote debugger port 

### DIFF
--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -29,6 +29,9 @@
                         <input type="checkbox" id="commands-preference-jsconsole" />Console
                     </label>
                     <label class="commands-options" style="display: none">
+                        Remote Debugger Port:
+                        <span id="commands-preference-remote-debugger-port"></span>
+                    <label class="commands-options" style="display: none">
                         Run:
                         <span id="commands-preference-default-app"></span>
                 </fieldset>

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -29,13 +29,17 @@
                         <input type="checkbox" id="commands-preference-jsconsole" />Console
                     </label>
                     <label class="commands-options" style="display: none">
-                        Remote Debugger Port:
-                        <span id="commands-preference-remote-debugger-port"></span>
-                        <br/>
-                        <button id="open-connect-devtools" title "Open Connect Remote DeveloperTools tab." onclick="Simulator.openConnectDevTools()">Connect DevTools</button>
+                        <div id="show-debugger-port">
+                          Remote Debugger Port:
+                          <span id="commands-preference-remote-debugger-port"></span>
+                        </div>
+                        <button id="open-connect-devtools" title="Connect Developer Tools..." 
+                                onclick="Simulator.openConnectDevtools()">Connect...</button>
+                    </label>
                     <label class="commands-options" style="display: none">
-                        Run:
-                        <span id="commands-preference-default-app"></span>
+                      Run:
+                      <span id="commands-preference-default-app"></span>
+                    </label>
                 </fieldset>
                 <!--<small>B2G v0.8</small>-->
                 <nav>

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -31,6 +31,8 @@
                     <label class="commands-options" style="display: none">
                         Remote Debugger Port:
                         <span id="commands-preference-remote-debugger-port"></span>
+                        <br/>
+                        <button id="open-connect-devtools" title "Open Connect Remote DeveloperTools tab." onclick="Simulator.openConnectDevTools()">Connect DevTools</button>
                     <label class="commands-options" style="display: none">
                         Run:
                         <span id="commands-preference-default-app"></span>

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -76,6 +76,12 @@ var Simulator = {
               $(Simulator.toggler).prop('checked', true);
               remoteDebuggerPortEl.html(message.remoteDebuggerPort);
               remoteDebuggerPortEl.parents('label').show();
+              // NOTE: show connect devtools buttons only when it's supported
+              if (message.hasConnectDevTools) {
+                $("#open-connect-devtools").show();
+              } else {
+                $("#open-connect-devtools").hide();
+              }
             }
             else {
               $(Simulator.toggler).prop('checked', false);

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -242,6 +242,10 @@ var Simulator = {
 
   addAppByDirectory: function() {
     window.postMessage({ name: "addAppByDirectory" }, "*");
+  },
+
+  openConnectDevTools: function() {
+    window.postMessage({ name: "openConnectDevTools" }, "*");
   }
 
 };

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -71,11 +71,16 @@ var Simulator = {
         switch (message.name) {
           case "isRunning":
             $(Simulator.toggler).prop('indeterminate', false);
+            var remoteDebuggerPortEl = $('#commands-preference-remote-debugger-port');
             if (message.isRunning) {
               $(Simulator.toggler).prop('checked', true);
+              remoteDebuggerPortEl.html(message.remoteDebuggerPort);
+              remoteDebuggerPortEl.parents('label').show();
             }
             else {
               $(Simulator.toggler).prop('checked', false);
+              $('#commands-preference-remote-debugger-port').html(message.remoteDebuggerPort);
+              remoteDebuggerPortEl.parents('label').hide();
             }
             break;
           case "listTabs":

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -76,10 +76,13 @@ var Simulator = {
               $(Simulator.toggler).prop('checked', true);
               remoteDebuggerPortEl.html(message.remoteDebuggerPort);
               remoteDebuggerPortEl.parents('label').show();
-              // NOTE: show connect devtools buttons only when it's supported
-              if (message.hasConnectDevTools) {
+              // NOTE: show connect devtools buttons where it's supported
+              //       and show allocated debugger port on previous firefox releases
+              if (message.hasConnectDevtools) {
+                $("#show-debugger-port").hide();
                 $("#open-connect-devtools").show();
               } else {
+                $("#show-debugger-port").show();
                 $("#open-connect-devtools").hide();
               }
             }
@@ -250,8 +253,8 @@ var Simulator = {
     window.postMessage({ name: "addAppByDirectory" }, "*");
   },
 
-  openConnectDevTools: function() {
-    window.postMessage({ name: "openConnectDevTools" }, "*");
+  openConnectDevtools: function() {
+    window.postMessage({ name: "openConnectDevtools" }, "*");
   }
 
 };

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -33,12 +33,12 @@ Cu.import("resource://gre/modules/Services.jsm");
 require("addon-page");
 
 const xulapp = require("sdk/system/xul-app");
-// NOTE: detect is developer toolbox feature can be enabled
+// NOTE: detect if developer toolbox feature can be enabled
 const HAS_CONNECT_DEVTOOLS = xulapp.is("Firefox") &&
   xulapp.versionInRange(xulapp.platformVersion, "20.0a1", "*");
 
-console.debug("XULAPP: ",xulapp.name,xulapp.version,xulapp.platformVersion);
-console.debug("HAS_CONNECT_DEVTOOLS: ",HAS_CONNECT_DEVTOOLS);
+console.debug("XULAPP: ", xulapp.name,xulapp.version, xulapp.platformVersion);
+console.debug("HAS_CONNECT_DEVTOOLS: ", HAS_CONNECT_DEVTOOLS);
 
 const RemoteSimulatorClient = require("remote-simulator-client");
 
@@ -589,7 +589,7 @@ let simulator = {
     this.openTab(simulator.contentPage, true);
   },
 
-  openConnectDevTools: function() {
+  openConnectDevtools: function() {
     let port = this.remoteSimulator.remoteDebuggerPort;
     Tabs.open({
       url: "chrome://browser/content/devtools/connect.xhtml",
@@ -674,13 +674,13 @@ let simulator = {
     if (simulator.worker) {
       let port = simulator.isRunning ?
         simulator.remoteSimulator.remoteDebuggerPort :
-        "none";
+        null;
 
       simulator.worker.postMessage({
         name: "isRunning",
         isRunning: simulator.isRunning,
         remoteDebuggerPort: port,
-        hasConnectDevTools: HAS_CONNECT_DEVTOOLS,
+        hasConnectDevtools: HAS_CONNECT_DEVTOOLS,
       });
     }
   },
@@ -708,8 +708,8 @@ let simulator = {
   onMessage: function onMessage(message) {
     console.log("Simulator.onMessage " + message.name);
     switch (message.name) {
-      case "openConnectDevTools":
-        simulator.openConnectDevTools();
+      case "openConnectDevtools":
+        simulator.openConnectDevtools();
         break;
       case "getIsRunning":
         simulator.postIsRunning();

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -683,7 +683,9 @@ let simulator = {
     console.log("Simulator.onMessage " + message.name);
     switch (message.name) {
       case "getIsRunning":
+        let port = this.remoteSimulator.remoteDebuggerPort;
         this.worker.postMessage({ name: "isRunning",
+                                  remoteDebuggerPort: port,
                                   isRunning: this.isRunning });
         break;
       case "addAppByDirectory":

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -581,6 +581,19 @@ let simulator = {
     this.openTab(simulator.contentPage, true);
   },
 
+  openConnectDevTools: function() {
+    let port = this.remoteSimulator.remoteDebuggerPort;
+    Tabs.open({
+      url: "chrome://browser/content/devtools/connect.xhtml",
+      onReady: function(tab) {
+        // NOTE: inject the allocated remoteDebuggerPort on the opened tab
+        tab.attach({
+          contentScript: "window.addEventListener('load', function() { document.getElementById('port').value = '"+port+"'; }, true);"
+        });
+      }
+    });
+  },
+
   kill: function(onKilled) {
     // WORKAROUND: currently add and update an app will be executed
     // as a simulator.kill callback
@@ -682,6 +695,9 @@ let simulator = {
   onMessage: function onMessage(message) {
     console.log("Simulator.onMessage " + message.name);
     switch (message.name) {
+      case "openConnectDevTools":
+        simulator.openConnectDevTools();
+        break;
       case "getIsRunning":
         let port = this.remoteSimulator.remoteDebuggerPort;
         this.worker.postMessage({ name: "isRunning",


### PR DESCRIPTION
Change needed to help developers to connect the upcoming remote developer tools to debug or interact with remote webconsole on the running b2g instance:
- show connect button on Firefox >= 20.0a1 (where connect devtools xhtml page is available)
- show allocated remote debugger port on previous Firefox releases as fallback
