### PR TITLE
remove app using mozApps uninstall and reinstall on undo remove

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -121,15 +121,25 @@ let simulator = {
       }
       console.log("Stored " + JSON.stringify(apps[webappFile]));
 
-      this.updateApp(webappFile);
+      this.updateApp(webappFile, function next(error, appId) {
+        // app reinstall completed
+        // success/error detection and report to the user
+        if (error) {
+          simulator.error(error);
+        }
+        simulator.sendListApps();
+      });
     }
   },
 
   updateAll: function() {
     this.run(function () {
-      function next() {
+      function next(error, appId) {
         // Call iterator.next() in a timeout to ensure updateApp() has returned;
         // otherwise we might raise "TypeError: already executing generator".
+        if (error) {
+          simulator.error(error);
+        }
         Timer.setTimeout(function() {
           try {
             iterator.next();
@@ -228,12 +238,18 @@ let simulator = {
       // NOTE: remote simulator.defaultApp because on the first run the app
       //       will be not already installed
       simulator.defaultApp = null;
-      console.log("INSTALLING ",config.xkey);
+      console.log("Requesting webappsActor to install packaged app: ",config.xkey);
       simulator.run(function() {
         simulator.remoteSimulator.install(config.xkey, null, function(res) {
-          console.debug("INSTALL RESPONSE: ",JSON.stringify(res));
+          console.debug("webappsActor install packaged app reply: ",
+                        JSON.stringify(res));
           if (next) {
-            next();
+            // detect success/error and report to the "next" callback
+            if (res.error) {
+              next(res.error + ": "+res.message, res.appId);
+            } else {
+              next(null, res.appId);
+            }
           }
         });
       });
@@ -288,11 +304,17 @@ let simulator = {
               // DISABLED: because on the first run the app will be not already installed
               simulator.defaultApp = null;
               simulator.run(function() {
-                console.log("INSTALLING ",config.xkey);
+                console.log("Requesting webappsActor to install hosted app: ",config.xkey);
                 simulator.remoteSimulator.install(config.xkey, null, function(res) {
-                  console.debug("INSTALL RESPONSE: ",JSON.stringify(res));
+                  console.debug("webappsActor install hosted app reply: ",
+                                JSON.stringify(res));
                   if (next) {
-                    next();
+                    // detect success/error and report to the "next" callback
+                    if (res.error) {
+                      next(res.error + ": "+res.message, res.appId);
+                    } else {
+                      next(null, res.appId);
+                    }
                   }
                 });
               });
@@ -319,11 +341,11 @@ let simulator = {
 
     simulator.run(function() {
       simulator.remoteSimulator.uninstall(config.origin, function() {
-        // TODO: show info to user  
+        // app uninstall completed
+        // TODO: add success/error detection and report to the user
+        simulator.sendListApps();
       });
     });
-
-    simulator.sendListApps();
   },
 
   undoRemoveApp: function(id) {
@@ -337,9 +359,14 @@ let simulator = {
     config.removed = false;
     apps[id] = config;
 
-    simulator.updateApp(id);
-
-    simulator.sendListApps();
+    simulator.updateApp(id, function next(error, appId) {
+      // app reinstall completed
+      // success/error detection and report to the user
+      if (error) {
+        simulator.error(error);
+      }
+      simulator.sendListApps();
+    });
   },
 
   removeAppFinal: function(id) {
@@ -350,12 +377,10 @@ let simulator = {
       return;
     }
 
+    // remove from the registered app list
     delete apps[id];
 
-    let webappsDir = URL.toFilename(profileURL + "webapps");
-    let webappsFile = File.join(webappsDir, "webapps.json");
-    let webapps = JSON.parse(File.read(webappsFile));
-
+    // cleanup registered permissions
     let permissions = simulator.permissions;
     if (permissions[config.origin]) {
       let host = config.host;
@@ -524,7 +549,12 @@ let simulator = {
     }
     console.log("Stored " + JSON.stringify(apps[id], null, 2));
 
-    this.updateApp(id);
+    this.updateApp(id, function next(error, appId) {
+      // success/error detection and report to the user
+      if (error) {
+        simulator.error(error);
+      }
+    });
   },
 
   sendListApps: function() {
@@ -685,7 +715,12 @@ let simulator = {
         this.sendListApps();
         break;
       case "updateApp":
-        simulator.updateApp(message.id);
+        simulator.updateApp(message.id, function next(error, appId) {
+          // success/error detection and report to the user
+          if (error) {
+            simulator.error(error);
+          }
+        });
         break;
       case "runApp":
         let appName = this.apps[message.id].name;

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -235,6 +235,14 @@ const RemoteSimulatorClient = Class({
                                 onResponse);
   },
 
+  uninstall: function(appOrigin, onResponse) {
+    this._remote.client.request({ to: this._remote.simulator,
+                                  type: "uninstallApp",
+                                  origin: appOrigin,
+                                },
+                                onResponse);
+  },
+
   // send a ping request to the remote simulator actor
   ping: function(onResponse) {
     let remote = this._remote;

--- a/prosthesis/content/simulator-actors.js
+++ b/prosthesis/content/simulator-actors.js
@@ -77,6 +77,34 @@ SimulatorActor.prototype = {
     };
   },
 
+  onUninstallApp: function(aRequest) {
+    log("simulator actor received 'uninstallApp' command: "+aRequest.origin);
+    let window = this.simulatorWindow;
+
+    let runnable = {
+      run: function() {
+        try {
+          let mgmt = window.navigator.mozApps.mgmt;
+          let req = mgmt.uninstall({origin: aRequest.origin});
+          req.onsuccess = function () {
+            log("uninstallApp success: "+req.result);
+          }
+          req.onerror = function () {
+            log("uninstallApp error: "+req.error.name);
+          }
+        } catch(e) {
+          log(e);
+        }
+      }
+    };
+
+    Services.tm.currentThread.dispatch(runnable,
+                                       Ci.nsIThread.DISPATCH_NORMAL);
+    return {
+      message: "uninstallApp request received"
+    };
+  },
+
   onSubscribeWindowManagerEvents: function (aRequest) {
     log("simulator actor received a 'subscribeWindowManagerEvents' command");
     let ok = this._subscribeWindowManagerEvents();
@@ -179,6 +207,7 @@ SimulatorActor.prototype.requestTypes = {
   "getBuildID": SimulatorActor.prototype.onGetBuildID,
   "logStdout": SimulatorActor.prototype.onLogStdout,
   "runApp": SimulatorActor.prototype.onRunApp,
+  "uninstallApp": SimulatorActor.prototype.onUninstallApp,
   "subscribeWindowManagerEvents": SimulatorActor.prototype.onSubscribeWindowManagerEvents,
   "unsubscribeWindowManagerEvents": SimulatorActor.prototype.onUnsubscribeWindowManagerEvents,
 };


### PR DESCRIPTION
This change adds an unistallApp command to the custom simulatorActor, which use mozApps.mgmt.uninstall to uninstall app by origin.

The app will be removed immediately when the user click the remove link (as most of the users expect to happen) and will be reinstalled immediately if the user click the undo button.  
