### PR TITLE
change runApp command to use mozApps API and app origin

### DIFF
--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -219,10 +219,10 @@ const RemoteSimulatorClient = Class({
   },
 
   // send a runApp request to the remote simulator actor
-  runApp: function(appname, onResponse) {
+  runApp: function(appOrigin, onResponse) {
     let remote = this._remote;
 
-    remote.client.request({to: remote.simulator, type: "runApp", appname: appname}, 
+    remote.client.request({to: remote.simulator, type: "runApp", origin: appOrigin},
                           onResponse);
   },
 

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -124,7 +124,7 @@ let simulator = module.exports = {
       }
       console.log("Stored " + JSON.stringify(apps[webappFile]));
 
-      this.updateApp(webappFile, function next(error, appId) {
+      this.updateApp(webappFile, function next(error, app) {
         // app reinstall completed
         // success/error detection and report to the user
         if (error) {
@@ -139,7 +139,7 @@ let simulator = module.exports = {
 
   updateAll: function() {
     this.run(function () {
-      function next(error, appId) {
+      function next(error, app) {
         // Call iterator.next() in a timeout to ensure updateApp() has returned;
         // otherwise we might raise "TypeError: already executing generator".
         if (error) {

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -129,8 +129,10 @@ let simulator = module.exports = {
         // success/error detection and report to the user
         if (error) {
           simulator.error(error);
+        } else {
+          simulator.sendListApps();
+          simulator.runApp(app.origin);
         }
-        simulator.sendListApps();
       });
     }
   },
@@ -255,15 +257,14 @@ let simulator = module.exports = {
               if (next) {
                 // detect success/error and report to the "next" callback
                 if (res.error) {
-                  next(res.error + ": " + res.message, res.appId);
+                  next(res.error + ": " + res.message, config);
                 } else {
-                  next(null, res.appId);
+                  next(null, config);
                 }
               }
             });
           });
         }
-
       });
     } else {
       // Hosted App
@@ -323,9 +324,9 @@ let simulator = module.exports = {
                   if (next) {
                     // detect success/error and report to the "next" callback
                     if (res.error) {
-                      next(res.error + ": "+res.message, res.appId);
+                      next(res.error + ": "+res.message, config);
                     } else {
-                      next(null, res.appId);
+                      next(null, config);
                     }
                   }
                 });
@@ -371,13 +372,15 @@ let simulator = module.exports = {
     config.removed = false;
     apps[id] = config;
 
-    simulator.updateApp(id, function next(error, appId) {
+    simulator.updateApp(id, function next(error, app) {
       // app reinstall completed
       // success/error detection and report to the user
       if (error) {
         simulator.error(error);
+      } else {
+        simulator.sendListApps();
+        simulator.runApp(app.origin);
       }
-      simulator.sendListApps();
     });
   },
 
@@ -561,10 +564,13 @@ let simulator = module.exports = {
     }
     console.log("Stored " + JSON.stringify(apps[id], null, 2));
 
-    this.updateApp(id, function next(error, appId) {
+    this.updateApp(id, function next(error, app) {
       // success/error detection and report to the user
       if (error) {
         simulator.error(error);
+      } else {
+        simulator.sendListApps();
+        simulator.runApp(app.origin);
       }
     });
   },
@@ -686,6 +692,13 @@ let simulator = module.exports = {
     }
   },
 
+  runApp: function(appOrigin, next) {
+    let cmd = (function () {
+      this.remoteSimulator.runApp(appOrigin, next);
+    }).bind(this);
+    this.run(cmd);
+  },
+
   get isRunning() {
     return this.remoteSimulator.isRunning;
   },
@@ -746,24 +759,19 @@ let simulator = module.exports = {
         this.sendListApps();
         break;
       case "updateApp":
-        simulator.updateApp(message.id, function next(error, appId) {
+        simulator.updateApp(message.id, function next(error, app) {
           // success/error detection and report to the user
           if (error) {
             simulator.error(error);
+          } else {
+            simulator.sendListApps();
+            simulator.runApp(app.origin);
           }
         });
         break;
       case "runApp":
         let appOrigin = this.apps[message.id].origin;
-
-        let cmd = function () {
-          this.remoteSimulator.runApp(appOrigin, function (response) {
-            console.debug("RUNAPP RESPONSE: "+JSON.stringify(response));
-            // TODO: send feedback to manager tab
-          });
-        };
-        cmd = cmd.bind(this);
-        this.run(cmd);
+        simulator.runApp(appOrigin);
         break;
       case "removeApp":
         this.removeApp(message.id);

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -693,10 +693,9 @@ let simulator = module.exports = {
   },
 
   runApp: function(appOrigin, next) {
-    let cmd = (function () {
-      this.remoteSimulator.runApp(appOrigin, next);
-    }).bind(this);
-    this.run(cmd);
+    this.run(function () {
+      simulator.remoteSimulator.runApp(appOrigin, next);
+    });
   },
 
   get isRunning() {

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -754,10 +754,10 @@ let simulator = module.exports = {
         });
         break;
       case "runApp":
-        let appName = this.apps[message.id].name;
+        let appOrigin = this.apps[message.id].origin;
 
         let cmd = function () {
-          this.remoteSimulator.runApp(appName, function (response) {
+          this.remoteSimulator.runApp(appOrigin, function (response) {
             console.debug("RUNAPP RESPONSE: "+JSON.stringify(response));
             // TODO: send feedback to manager tab
           });

--- a/prosthesis/content/simulator-actors.js
+++ b/prosthesis/content/simulator-actors.js
@@ -128,19 +128,6 @@ SimulatorActor.prototype = {
     return {
       message: "runApp request received: "+appOrigin
     };
-
-    /*
-    window.runAppObj = new window.AppRunner(appName);
-
-    let setReq = window.navigator.mozSettings
-      .createLock().set({'lockscreen.enabled': false});
-    setReq.onsuccess = function() {
-      window.runAppObj.doRunApp();
-    }
-    return {
-      message: "runApp request received"
-    };
-    */
   },
 
   onUninstallApp: function(aRequest) {

--- a/prosthesis/content/simulator-actors.js
+++ b/prosthesis/content/simulator-actors.js
@@ -61,7 +61,7 @@ SimulatorActor.prototype = {
   },
 
   onRunApp: function(aRequest) {
-    log("simulator actor received a 'runApp' command:"+aRequest.origin);
+    log("simulator actor received a 'runApp' command:" + aRequest.origin);
     let window = this.simulatorWindow;
     let appOrigin = aRequest.origin;
 
@@ -70,25 +70,25 @@ SimulatorActor.prototype = {
         try {
           runnable.unlockScreen(function(e) {
             if (e) {
-              log("ERROR: "+e);
+              log("ERROR: " + e);
               return;
             }
             runnable.findAppByOrigin(appOrigin, function (e, app) {
               if (e) {
-                log("ERROR: "+e);
+                log("ERROR: " + e);
                 return;
               }
               try {
-                log("RUNAPP LAUNCHING:"+app.origin);
+                log("RUNAPP LAUNCHING:" + app.origin);
                 app.launch();
-                log("RUNAPP SUCCESS:"+appOrigin);
+                log("RUNAPP SUCCESS:" + appOrigin);
               } catch(e) {
-                log("EXCEPTION: "+e);
+                log("EXCEPTION: " + e);
               }
             });
           });
         } catch(e) {
-          log("EXCEPTION: "+e);
+          log("EXCEPTION: " + e);
         }
       },
       unlockScreen: function(cb) {
@@ -126,12 +126,12 @@ SimulatorActor.prototype = {
     Services.tm.currentThread.dispatch(runnable,
                                        Ci.nsIThread.DISPATCH_NORMAL);
     return {
-      message: "runApp request received: "+appOrigin
+      message: "runApp request received: " + appOrigin
     };
   },
 
   onUninstallApp: function(aRequest) {
-    log("simulator actor received 'uninstallApp' command: "+aRequest.origin);
+    log("simulator actor received 'uninstallApp' command: " + aRequest.origin);
     let window = this.simulatorWindow;
 
     let runnable = {
@@ -140,10 +140,10 @@ SimulatorActor.prototype = {
           let mgmt = window.navigator.mozApps.mgmt;
           let req = mgmt.uninstall({origin: aRequest.origin});
           req.onsuccess = function () {
-            log("uninstallApp success: "+req.result);
+            log("uninstallApp success: " + req.result);
           }
           req.onerror = function () {
-            log("uninstallApp error: "+req.error.name);
+            log("uninstallApp error: " + req.error.name);
           }
         } catch(e) {
           log(e);


### PR DESCRIPTION
Change simulatorActor runApp command to use app origin to find and launch an installed app.
This change prevents the b2g-instance to exit if the application is not currently installed and doesn't launch the wrong app if you app share the same name.

 NOTE: runApp doesn't always show the app when the simulator instance
 is not already running, because the homescreen is not yet fully loaded and
 the app will start in background (reachable by pressing the home button to reach
 the gaia tasks list)
