### PR TITLE
FIX: adb executable uri is "data/linux64" on XPCOMABI x86_64

### DIFF
--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -67,7 +67,11 @@ this.ADB = {
     let bin;
     switch(platform) {
       case "Linux":
-        bin = uri + "linux/adb";
+        if (COMMONJS_MODULE) {
+          bin = uri + (require("runtime").XPCOMABI.indexOf("x86_64") == 0 ? "linux64" : "linux") + "/adb";
+        } else {
+          bin = uri + "linux/adb";
+        }
         break;
       case "Darwin":
         if (COMMONJS_MODULE) {


### PR DESCRIPTION
Last Makefile changes use same conventions as b2g binaries and on Linux platform
and puts executables into data/linux64 on 64bit systems and linux on 32bit systems.

This change fix the adb.js package to use the right path on 64bit systems.
