### PR TITLE
trim curly braces from UUIDs used as app IDs

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -41,7 +41,7 @@ function ensureXkeysUnique() {
     let app = Simulator.apps[key];
 
     // Give the app a new unique xkey.
-    app.xkey = UUID.uuid().toString();
+    app.xkey = UUID.uuid().toString().slice(1, -1);
 
     // For "local" (i.e. packaged) apps, make the origin and manifest URL match
     // the xkey, since we'll use the xkey as the ID of the app in

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -34,9 +34,11 @@ PageMod({
 });
 
 /**
- * Ensure app xkeys are unique.
+ * Ensure app xkeys are valid, since older versions of the addon created
+ * invalid ones (not guaranteed to be unique, or containing curly braces,
+ * which are invalid in app: URLs).
  */
-function ensureXkeysUnique() {
+function ensureXkeysValid() {
   for (let key in Simulator.apps) {
     let app = Simulator.apps[key];
 
@@ -71,8 +73,8 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
       filter(function (appId) !Simulator.apps[appId].deleted);
 
     if (activeAppIds.length > 0) {
-      if (Services.vc.compare(lastVersion, "2.0pre5") < 0) {
-        ensureXkeysUnique();
+      if (Services.vc.compare(lastVersion, "3.0pre3") < 0) {
+        ensureXkeysValid();
       }
       SStorage.storage.needsUpdateAll = true;
     }

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -213,7 +213,7 @@ let simulator = module.exports = {
       // if the emulator doesn't exit clean DOMApplicationRegistry._nextLocalId
       // will not be able to serialize "dom.mozApps.maxLocalId" and will be the
       // same for new app installed
-      config.xkey = UUID.uuid().toString(); //"myapp" + config.xid + ".gaiamobile.org";
+      config.xkey = UUID.uuid().toString().slice(1, -1);
 
       if (!config.origin) {
         config.origin = "app://" + config.xkey;


### PR DESCRIPTION
[Over in dev-b2g](https://groups.google.com/d/topic/mozilla.dev.b2g/j-r8ed6yAS4/discussion), @ArnaudD reported that an app he was testing in the Simulator had an app:// URL with a GUID containing curly braces, which violates RFC 3986.

@fabricedesre is fixing B2G's app ID generator to trim the braces in [bug 845344](https://bugzilla.mozilla.org/show_bug.cgi?id=845344). We should similarly fix the Simulator's app ID generator.
