### PR TITLE
FIX: prevents default on "validation errors link" click handler

### DIFF
--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -268,6 +268,7 @@ var Simulator = {
                       .prop("title", "expand validation messages")
                       .click(function(evt) {
                         listContainerEl.toggle();
+                        return false;
                       }),
                     listContainerEl);
                 } else {


### PR DESCRIPTION
fix #352

IMPLEMENTATION NOTE: "return false;" in a jQuery event handler is effectively the same as calling both event.preventDefault and event.stopPropagation (http://stackoverflow.com/a/1357151)
