### PR TITLE
FIX: prevent silent errors on add/undo error

### DIFF
--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -232,6 +232,8 @@ var Simulator = {
                 var errors = app.validation.errors;
                 var warnings = app.validation.warnings;
 
+                var validationResultText = app.validation.running ? "RUNNING": "";
+
                 if (errors.length > 0 || warnings.length > 0) {
                   var listContainerEl = $("<ul class='app-validation-list'>");
 
@@ -259,9 +261,13 @@ var Simulator = {
 
                   listContainerEl.hide();
 
+                  if (!app.validation.running) {
+                    validationResultText = warnings.length === 0 ? "WARNINGS" : "INVALID";
+                  }
+
                   validationEl.append(
                     $("<span>")
-                      .text("Validation Result: INVALID")
+                      .text("Validation Result: " + validationResultText)
                       .prop("class", "app-validation-result"),
                     $("<a href='#'>")
                       .text(" ("+errors.length+" errors and "+warnings.length+" warnings)")
@@ -272,9 +278,10 @@ var Simulator = {
                       }),
                     listContainerEl);
                 } else {
+                  validationResultText = !app.validation.running ? "OK" : validationResultText;
                   validationEl.append(
                     $("<span>")
-                      .text("Validation Result: OK")
+                      .text("Validation Result: " + validationResultText)
                       .prop("class", "app-validation-result"));
                 }
 

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -117,11 +117,10 @@ let simulator = module.exports = {
       this.updateApp(manifestFile, function next(error, app) {
         // app reinstall completed
         // success/error detection and report to the user
+        simulator.sendListApps();
         if (error) {
-          simulator.sendListApps();
           simulator.error(error);
         } else {
-          simulator.sendListApps();
           simulator.runApp(app);
         }
       });
@@ -179,6 +178,10 @@ let simulator = module.exports = {
 
   updateApp: function(id, next) {
     console.log("Simulator.updateApp " + id);
+    // refresh app list on the dashboard before validation
+    // (prevents silent errors on a stalled validation)
+    simulator.sendListApps();
+
     simulator.validateApp(id, function(error, app) {
       // update dashboard app validation info
       simulator.sendListApps();
@@ -411,11 +414,10 @@ let simulator = module.exports = {
     simulator.updateApp(id, function next(error, app) {
       // app reinstall completed
       // success/error detection and report to the user
+      simulator.sendListApps();
       if (error) {
-        simulator.sendListApps();
         simulator.error(error);
       } else {
-        simulator.sendListApps();
         simulator.runApp(app);
       }
     });
@@ -605,11 +607,10 @@ let simulator = module.exports = {
 
     this.updateApp(id, function next(error, app) {
       // success/error detection and report to the user
+      simulator.sendListApps();
       if (error) {
-        simulator.sendListApps();
         simulator.error(error);
       } else {
-        simulator.sendListApps();
         simulator.runApp(app);
       }
     });
@@ -1047,12 +1048,11 @@ let simulator = module.exports = {
         break;
       case "updateApp":
         simulator.updateApp(message.id, function next(error, app) {
+          simulator.sendListApps();
           // success/error detection and report to the user
           if (error) {
-            simulator.sendListApps();
             simulator.error(error);
           } else {
-            simulator.sendListApps();
             simulator.runApp(app);
           }
         });

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -118,8 +118,10 @@ let simulator = module.exports = {
         // app reinstall completed
         // success/error detection and report to the user
         if (error) {
+          simulator.sendListApps();
           simulator.error(error);
         } else {
+          simulator.sendListApps();
           simulator.runApp(app);
         }
       });
@@ -410,6 +412,7 @@ let simulator = module.exports = {
       // app reinstall completed
       // success/error detection and report to the user
       if (error) {
+        simulator.sendListApps();
         simulator.error(error);
       } else {
         simulator.sendListApps();
@@ -603,6 +606,7 @@ let simulator = module.exports = {
     this.updateApp(id, function next(error, app) {
       // success/error detection and report to the user
       if (error) {
+        simulator.sendListApps();
         simulator.error(error);
       } else {
         simulator.sendListApps();
@@ -1045,6 +1049,7 @@ let simulator = module.exports = {
         simulator.updateApp(message.id, function next(error, app) {
           // success/error detection and report to the user
           if (error) {
+            simulator.sendListApps();
             simulator.error(error);
           } else {
             simulator.sendListApps();

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -200,8 +200,11 @@ let simulator = module.exports = {
           return;
         }
       }
-      // update dashboard app validation info to prevents silent errors
-      // on stalled validations
+
+      // Update the app listing on the Dashboard.  We do this again after
+      // validation, but validation can stall and never call our callback;
+      // and we want to make sure the app listing is updated with the info
+      // we just got from the manifest; so we do it here as well.
       simulator.sendListApps();
 
       simulator.validateApp(id, function(error, app) {


### PR DESCRIPTION
prevent silent errors in the dashboard due to an b2g-desktop instance stalled:
- call simulator.sendListApps on add/undo error to immediatelly list the new app
- update and check cached manifest before validation (to be able to update the app name in the dashboard)
- define a new app.validation.running attribute
- dashboard app validation result text: RUNNING, WARNINGS, INVALID, OK

should fix #374 and #365
