### PR TITLE
FIX: random allocated b2g debugger remoteport saved as connect page submit side-effect

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -56,6 +56,12 @@ function ensureXkeysValid() {
   }
 }
 
+// Restore standard remote debugger port
+// (autosaved on submit by connect.xhtml on simulator < 3.0pre5)
+function restoreStardardRemoteDebuggerPort() {
+  Services.prefs.setIntPref("devtools.debugger.remote-port", 6000);
+}
+
 // Retrieve the last addon version from storage, and update storage if it
 // has changed, so we can do work on addon upgrade/downgrade that depends on
 // the last version the user used.
@@ -76,7 +82,9 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
       if (Services.vc.compare(lastVersion, "3.0pre3") < 0) {
         ensureXkeysValid();
       }
-      SStorage.storage.needsUpdateAll = true;
+      if (Services.vc.compare(lastVersion, "3.0pre5") < 0) {
+        SStorage.storage.needsUpdateAll = true;
+      }
     }
   }
 }

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -58,7 +58,7 @@ function ensureXkeysValid() {
 
 // Restore standard remote debugger port
 // (autosaved on submit by connect.xhtml on simulator < 3.0pre5)
-function restoreStardardRemoteDebuggerPort() {
+function restoreStandardRemoteDebuggerPort() {
   Services.prefs.setIntPref("devtools.debugger.remote-port", 6000);
 }
 
@@ -83,8 +83,9 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
         ensureXkeysValid();
       }
       if (Services.vc.compare(lastVersion, "3.0pre5") < 0) {
-        SStorage.storage.needsUpdateAll = true;
+        restoreStandardRemoteDebuggerPort();
       }
+      SStorage.storage.needsUpdateAll = true;
     }
   }
 }

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -860,12 +860,16 @@ let simulator = module.exports = {
 
   openConnectDevtools: function() {
     let port = this.remoteSimulator.remoteDebuggerPort;
+    let originalPort = Services.prefs.getIntPref("devtools.debugger.remote-port");
     Tabs.open({
-      url: "chrome://browser/content/devtools/connect.xhtml",
+      url: "chrome://browser/content/devtools/connect.xhtml",      
       onReady: function(tab) {
         // NOTE: inject the allocated remoteDebuggerPort on the opened tab
         tab.attach({
           contentScript: "window.addEventListener('load', function() { document.getElementById('port').value = '"+port+"'; }, true);"
+        }).on('detach', function restoreOriginalRemotePort() {
+          // restore previous value (autosaved on submit by connect.xhtml)
+          Services.prefs.setIntPref("devtools.debugger.remote-port", originalPort);
         });
       }
     });

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -862,7 +862,7 @@ let simulator = module.exports = {
     let port = this.remoteSimulator.remoteDebuggerPort;
     let originalPort = Services.prefs.getIntPref("devtools.debugger.remote-port");
     Tabs.open({
-      url: "chrome://browser/content/devtools/connect.xhtml",      
+      url: "chrome://browser/content/devtools/connect.xhtml",
       onReady: function(tab) {
         // NOTE: inject the allocated remoteDebuggerPort on the opened tab
         tab.attach({


### PR DESCRIPTION
Trying to use the new experimental Browser Debugger in Firefox Nightly
to debug simulator addon code,
I notice that it doesn't work on my profile because connect.xhtml saved
random allocated port as a side effect of the submit action:

https://mxr.mozilla.org/mozilla-central/source/browser/devtools/framework/connect/connect.js#55

and so Firefox try to start a debugger server on the same port of the connected b2g instance.

proposed changes to workaround this bug:
- restore previously saved remote debugger port on connect.xhtml tab close
- on install/upgrade restore standard remote debugger port (6000) if previously
  installed version < 3.0pre5  
