### PR TITLE
FIX: add return value to onGeolocationRequest actor command handler to prevents muted remote debugger actor problem

### DIFF
--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -355,6 +355,11 @@ SimulatorActor.prototype = {
         lon: aRequest.message.lon,
       }
     }, "r2d2b2g-geolocation-setup", null);
+
+    return {
+      message: "geolocationRequest request received",
+      success: true
+    };
   },
 
   get homescreenWindow() {


### PR DESCRIPTION
apparently every actor handler needs to return a value to fully prevents
the muted debugger actor/connection problem (or needs to send a
reply to the client)
(https://bugzilla.mozilla.org/show_bug.cgi?id=855509)
