### PR TITLE
FEATURE: remote scratchpad 

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -183,6 +183,15 @@ Gcli.addCommand({
   },
 });
 
+Gcli.addCommand({
+  name: "firefoxos scratchpad",
+  description: "...",
+  params: [],
+  exec: function(args, context) {
+    Simulator.remoteSimulator.openScratchpad();
+  },
+});
+
 let PermissionSettings;
 try {
   PermissionSettings =

--- a/addon/lib/remote-scratchpad.js
+++ b/addon/lib/remote-scratchpad.js
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { Cc, Ci, Cu, ChromeWorker } = require("chrome");
+
+let SCRATCHKIT_URI = 'resource:///modules/devtools/scratchpad-manager.jsm'
+let { ScratchpadManager } = Cu.import(SCRATCHKIT_URI)
+
+const APP_CONTEXT = 1;
+const CHROME_CONTEXT = 2;
+const BROWSER_TAB_CONTEXT = 3;
+
+function Scratchpad(options) {
+  let { sandbox, text, filename, unload, open, client } = options;
+
+  let statusText = client.isConnected ? "CONNECTED" : "NOT CONNECTED";
+
+  let window = ScratchpadManager.openScratchpad({
+    text: text || '// FirefoxOS Simulator Scratchpad\n// '+statusText+'\n'
+  })
+
+  window.addEventListener('DOMContentLoaded', function onready() {
+    window.addEventListener('unload', function onunload() {
+      window.removeEventListener('unload', onunload)
+      unload && unload()
+    })
+
+    window.removeEventListener('DOMContentLoaded', onready)
+
+    let scratchpad = window.Scratchpad
+
+    let parent = window.document.querySelector("#sp-menu-environment");
+    parent.querySelector("#sp-menu-content").
+           setAttribute("label", "FirefoxOS App");
+    parent.querySelector("#sp-menu-browser").
+           setAttribute("label", "FirefoxOS Shell")
+    let menuitem = window.document.createElement("menuitem");
+    menuitem.id = "sp-menu-browser-tab"
+    menuitem.setAttribute("type", "radio");
+    menuitem.setAttribute("label", "FirefoxOS Browser Tab");
+    menuitem.addEventListener("click", (function () {
+      this.executionContext = BROWSER_TAB_CONTEXT;
+      return true;
+    }).bind(scratchpad));
+
+    parent.appendChild(menuitem);
+
+    let { writeAsComment, openScratchpad } = scratchpad
+    open = open || openScratchpad
+
+    Object.defineProperties(scratchpad, {
+      _evalInSandbox: {
+        configurable: true,
+        value: function(cb) {
+          let selection = this.selectedText || this.getText();
+          let context;
+
+          switch (this.executionContext) {
+          case BROWSER_TAB_CONTEXT:
+            context = "browser-tab";
+            break;
+          case CHROME_CONTEXT:
+            context = "chrome";
+            break;
+          case APP_CONTEXT:
+            context = "app";
+            break;
+          }
+
+          if (client.isConnected) {
+            client.evalInSandbox(selection, context, this.uniqueName, cb);
+          } else {
+            this.writeAsErrorComment("ERROR: client not connected");
+          }
+        }
+      },
+      _setTitle: {
+        configurable: true,
+        value: function (name, location) {
+          let title = "Scratchpad - " + name + " - " + location;
+          window.document.documentElement.setAttribute("title", title);
+        }
+      },
+      run: {
+        configurable: true,
+        value: function() {
+          this._evalInSandbox((function onResponse(pkt) {
+            if (pkt.error) {
+              this.writeAsErrorComment(pkt.error);
+              return;
+            }
+
+            let data = pkt.scratchpad;
+            this._setTitle(data.name, data.location);
+
+            if (!data.error) {
+              this.deselect();
+            } else {
+                this.writeAsErrorComment(data.error);
+            }
+          }).bind(this));
+        }
+      },
+      inspect: {
+        configurable: true,
+        value: function() {
+          this.writeAsErrorComment("ERROR: 'Inspect' not yet implemented on remote scratchpad");
+        }
+      },
+      reloadAndRun: {
+        configurable: true,
+        value: function() {
+          this.writeAsErrorComment("ERROR: 'Reload and Run' not yet implemented on remote scratchpad");
+        }
+      },
+      display: {
+        configurable: true,
+        value: function() {
+          this._evalInSandbox((function onResponse(pkt) {
+            if (pkt.error) {
+              this.writeAsErrorComment(pkt.error);
+              return;
+            }
+
+            let data = pkt.scratchpad;
+            this._setTitle(data.name, data.location);
+
+            if (!data.error) {
+              this.writeAsComment(data.result);
+            } else {
+                this.writeAsErrorComment(data.error);
+            }
+          }).bind(this));
+        }
+      },
+      openPropertyPanel: {
+        configurable: true,
+        value: function () { },
+      },
+      chromeSandbox: {
+        configurable: true,
+        get: function() { }
+      },
+      contentSandbox: {
+        configurable: true,
+        get: function() { }
+      },
+      openScratchpad: {
+        configurable: true,
+        value: function() {
+          return open.call(this)
+        }
+      }
+    });
+  });
+
+  return window;
+}
+
+module.exports = Scratchpad;

--- a/addon/lib/remote-scratchpad.js
+++ b/addon/lib/remote-scratchpad.js
@@ -7,8 +7,8 @@
 
 const { Cc, Ci, Cu, ChromeWorker } = require("chrome");
 
-let SCRATCHKIT_URI = 'resource:///modules/devtools/scratchpad-manager.jsm'
-let { ScratchpadManager } = Cu.import(SCRATCHKIT_URI)
+let SCRATCHKIT_URI = 'resource:///modules/devtools/scratchpad-manager.jsm';
+let { ScratchpadManager } = Cu.import(SCRATCHKIT_URI);
 
 const APP_CONTEXT = 1;
 const CHROME_CONTEXT = 2;
@@ -21,25 +21,25 @@ function Scratchpad(options) {
 
   let window = ScratchpadManager.openScratchpad({
     text: text || '// FirefoxOS Simulator Scratchpad\n// '+statusText+'\n'
-  })
+  });
 
   window.addEventListener('DOMContentLoaded', function onready() {
     window.addEventListener('unload', function onunload() {
-      window.removeEventListener('unload', onunload)
-      unload && unload()
-    })
+      window.removeEventListener('unload', onunload);
+      unload && unload();
+    });
 
-    window.removeEventListener('DOMContentLoaded', onready)
+    window.removeEventListener('DOMContentLoaded', onready);
 
-    let scratchpad = window.Scratchpad
+    let scratchpad = window.Scratchpad;
 
     let parent = window.document.querySelector("#sp-menu-environment");
     parent.querySelector("#sp-menu-content").
            setAttribute("label", "FirefoxOS App");
     parent.querySelector("#sp-menu-browser").
-           setAttribute("label", "FirefoxOS Shell")
+           setAttribute("label", "FirefoxOS Shell");
     let menuitem = window.document.createElement("menuitem");
-    menuitem.id = "sp-menu-browser-tab"
+    menuitem.id = "sp-menu-browser-tab";
     menuitem.setAttribute("type", "radio");
     menuitem.setAttribute("label", "FirefoxOS Browser Tab");
     menuitem.addEventListener("click", (function () {
@@ -49,8 +49,8 @@ function Scratchpad(options) {
 
     parent.appendChild(menuitem);
 
-    let { writeAsComment, openScratchpad } = scratchpad
-    open = open || openScratchpad
+    let { writeAsComment, openScratchpad } = scratchpad;
+    open = open || openScratchpad;
 
     Object.defineProperties(scratchpad, {
       _evalInSandbox: {
@@ -139,7 +139,7 @@ function Scratchpad(options) {
       },
       openPropertyPanel: {
         configurable: true,
-        value: function () { },
+        value: function () { }
       },
       chromeSandbox: {
         configurable: true,
@@ -152,7 +152,7 @@ function Scratchpad(options) {
       openScratchpad: {
         configurable: true,
         value: function() {
-          return open.call(this)
+          return open.call(this);
         }
       }
     });

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -21,6 +21,7 @@ const { rootURI: ROOT_URI } = require('@loader/options');
 const PROFILE_URL = ROOT_URI + "profile/";
 
 const PingbackServer = require("pingback-server");
+const Scratchpad = require("remote-scratchpad");
 
 // import debuggerSocketConnect and DebuggerClient
 const dbgClient = Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
@@ -79,7 +80,8 @@ const RemoteSimulatorClient = Class({
           tabs: reply.tabs,
           selected: reply.selected,
           simulator: reply.simulatorActor,
-          webapps: reply.simulatorWebappsActor
+          webapps: reply.simulatorWebappsActor,
+          scratchpad: reply.scratchpadActor
         });
       }).bind(this));
     });
@@ -294,6 +296,23 @@ const RemoteSimulatorClient = Class({
                                 },
                                 onResponse);
   },
+
+  // BEGIN remote scratchpad helpers
+  openScratchpad: function() {
+    return Scratchpad({open: this.openScratchpad.bind(this),
+                       client: this});
+  },
+
+  evalInSandbox: function(text, context, uniqueName, onResponse) {
+    this._remote.client.request({to: this._remote.scratchpad,
+                                 context: context,
+                                 uniqueName: uniqueName,
+                                 text: text,
+                                 type: "evalInSandbox"},
+                                onResponse);
+  },
+
+  // END remote scratchpad helpers
 
   // send a ping request to the remote simulator actor
   ping: function(onResponse) {

--- a/prosthesis/content/dbg-scratchpad-actors.js
+++ b/prosthesis/content/dbg-scratchpad-actors.js
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+let Cu = Components.utils;
+let Cc = Components.classes;
+let Ci = Components.interfaces;
+
+function debug(aMsg) {
+/*  Cc["@mozilla.org/consoleservice;1"]
+    .getService(Ci.nsIConsoleService)
+    .logStringMessage("--*-- ScratchpadActor : " + aMsg);*/
+}
+
+Components.utils.import("resource://gre/modules/Services.jsm");
+
+let ScratchpadActor = function ScratchpadActor(aConnection) { debug("init"); }
+
+ScratchpadActor.prototype = {
+  actorPrefix: "scratchpad",
+
+  _stringify: function (value) {
+    return value ? value.toString() : "";
+  },
+
+  // { text, context, uniqueName } = request;
+  evalInSandbox: function evalInContentSandbox(request) {
+    if (["chrome", "app", "browser-tab"].indexOf(request.context) < 0) {
+      return {
+        error: "unkownContext"
+      };
+    }
+
+    let error, result, name, location;
+
+    try {
+      let sandbox, app, tab;
+
+      switch (request.context) {
+      case "chrome":
+        sandbox = this.chromeSandbox;
+        name = "Simulator";
+        location = this.browserWindow.location.href;
+        break;
+      case "app":
+        sandbox = this.appSandbox;
+        app = this.displayedApp;
+        name = app ? app.name : "";
+        location = this._previousAppLocation;
+        break;
+      case "browser-tab":
+        app = this.displayedApp;
+        if (!app || app.origin !== "app://browser.gaiamobile.org") {
+          return {
+            error: "browserNotDisplayed"
+          };
+        }
+        tab = this.displayedBrowserTab;
+        name = tab ? tab.dom.contentWindow.title : "";
+        sandbox = this.browserTabSandbox;
+        location = this._previousBrowserTabLocation;
+        break;
+      }
+
+      result = Cu.evalInSandbox(request.text, sandbox, "1.8",
+                                request.uniqueName, 1);
+    }
+    catch (ex) {
+      Cu.reportError(ex);
+      error = [ex.toString(), ex.fileName, ex.lineNumber].join(" ");
+    }
+
+    return {
+      scratchpad: {
+        name: name,
+        location: location,
+        error: error,
+        result: this._stringify(result)
+      }
+    };
+  },
+
+  get browserWindow() {
+    let win = Services.wm.getMostRecentWindow("navigator:browser");
+    return win;
+  },
+
+  _previousWindow: null,
+
+  get displayedApp() {
+    let win = this.browserWindow;
+    let home = win.wrappedJSObject.shell.contentBrowser.contentWindow.wrappedJSObject;
+
+    let app = home.WindowManager.getCurrentDisplayedApp();
+
+    return app ? app : null;
+  },
+
+  _appSandbox: null,
+
+  get appSandbox() {
+    if (!this.displayedApp) {
+      Cu.reportError("displayedApp.unavailable");
+      return;
+    }
+
+    let window = this.displayedApp.iframe.contentWindow;
+    let location = window.location.href;
+
+    if (!this._appSandbox ||
+        this.browserWindow != this._previousBrowserWindow ||
+        this._previousApp != this.displayedApp ||
+        this._previousAppLocation != location) {
+      this._appSandbox = new Cu.Sandbox(window,
+        { sandboxPrototype: window,
+          wantXrays: false,
+          sandboxName: 'scratchpad-app'
+        });
+
+      this._previousApp = this.displayedApp;
+      this._previousAppLocation = location;
+    }
+
+    return this._appSandbox;
+  },
+
+  get displayedBrowserTab() {
+    let app = this.displayedApp;
+
+    if (app) {
+      return app.iframe.contentWindow.Browser.currentTab;
+    }
+
+    return null;
+  },
+
+  _browserTabSandbox: null,
+  get browserTabSandbox() {
+    if (!this.displayedBrowserTab) {
+      Cu.reportError("displayedBrowserTab.unavailable");
+      return;
+    }
+
+    let window = this.displayedBrowserTab.dom.contentWindow;
+    let location = window.location.href;
+
+    if (!this._browserTabSandbox ||
+        this.browserWindow != this._previousBrowserWindow ||
+        this._previousBrowserTab != this.displayedBrowserTab ||
+        this._previousBrowserTabLocation != location) {
+      this._browserTabSandbox = new Cu.Sandbox(window,
+        { sandboxPrototype: window,
+          wantXrays: false,
+          sandboxName: 'scratchpad-browser-tab'
+        });
+
+      this._previousBrowserTab = this.displayedBrowserTab;
+      this._previousBrowserTabLocation = location;
+    }
+
+    return this._browserTabSandbox;
+  },
+
+  _chromeSandbox: null,
+
+  get chromeSandbox()
+  {
+    if (!this.browserWindow) {
+      Cu.reportError("browserWindow.unavailable");
+      return;
+    }
+
+    if (!this._chromeSandbox ||
+        this.browserWindow != this._previousBrowserWindow) {
+      this._chromeSandbox = new Cu.Sandbox(this.browserWindow,
+        { sandboxPrototype: this.browserWindow, wantXrays: false,
+          sandboxName: 'scratchpad-chrome'});
+
+      this._previousBrowserWindow = this.browserWindow;
+    }
+
+    return this._chromeSandbox;
+  },
+}
+
+ScratchpadActor.prototype.requestTypes = {
+  "evalInSandbox": ScratchpadActor.prototype.evalInSandbox
+};
+
+DebuggerServer.addGlobalActor(ScratchpadActor, "scratchpadActor");

--- a/prosthesis/content/patch-start-debugger.js
+++ b/prosthesis/content/patch-start-debugger.js
@@ -10,6 +10,7 @@
     DebuggerServer.addActors('chrome://prosthesis/content/dbg-simulator-actors.js');
     // NOTE: add temporary simulatorWebAppsActor
     DebuggerServer.addActors('chrome://prosthesis/content/dbg-webapps-actors.js');
+    DebuggerServer.addActors('chrome://prosthesis/content/dbg-scratchpad-actors.js');
     pingback();
   }
 


### PR DESCRIPTION
This prototype adds a new DevTools command ("firefoxos scratchpad")
to open a tweaked scratchpad window connected to the controlled 
b2g-desktop instance using a new custom "scratchpad actor", 
it supports 3 switchable contexts:
- current displayed FirefoxOS app context ("app")
- current FirefoxOS browser tab ("browser-tab")
- FirefoxOS Chrome shell.xul ("chrome")

Supported scratchpad features:
- run selection/buffer
- display selection/buffer
- load / save to file

Not supported scratchpad features:
- inspect (needs more work)
- reload and run
- reset variables

DEMO SCREENCAST: http://youtu.be/M8jW8F7OCJU
