### PR TITLE
suppress duplicate error notification when adding app (fixes #358)

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -134,12 +134,11 @@ let simulator = module.exports = {
       console.log("Registered App " + JSON.stringify(apps[manifestFile]));
 
       this.updateApp(manifestFile, function next(error, app) {
-        // app reinstall completed
-        // success/error detection and report to the user
+        // Update the Dashboard to reflect changes to the record and run the app
+        // if the update succeeded.  Otherwise, it isn't necessary to notify
+        // the user about the error, as it'll show up in the validation results.
         simulator.sendListApps();
-        if (error) {
-          simulator.error(error);
-        } else {
+        if (!error) {
           simulator.runApp(app);
         }
       });
@@ -651,11 +650,11 @@ let simulator = module.exports = {
     console.log("Registered App " + JSON.stringify(apps[id], null, 2));
 
     this.updateApp(id, function next(error, app) {
-      // success/error detection and report to the user
+      // Update the Dashboard to reflect changes to the record and run the app
+      // if the update succeeded.  Otherwise, it isn't necessary to notify
+      // the user about the error, as it'll show up in the validation results.
       simulator.sendListApps();
-      if (error) {
-        simulator.error(error);
-      } else {
+      if (!error) {
         simulator.runApp(app);
       }
     });


### PR DESCRIPTION
This change suppresses the error notification bar when you add an app, since the error also shows up in the validation results.

It doesn't suppress the error notification bar if you ignore the validation results and try to run an invalid app, however. In that case, the bar seems useful to remind you that the app is invalid and explain why your attempt to run it has failed.
