### PR TITLE
automatically configure prosthesis logging (fixes #378)

### DIFF
--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -49,7 +49,11 @@ if (!COMMONJS) {
 }
 
 function debug(aStr) {
-  dump("--*-- ADB.jsm: " + aStr + "\n");
+  if (COMMONJS) {
+    console.log("adb: " + aStr);
+  } else {
+    dump("--*-- ADB.jsm: " + aStr + "\n");
+  }
 }
 
 let ready = false;
@@ -273,7 +277,7 @@ this.ADB = {
       let data = aEvent.data;
       debug("length=" + data.length);
       let dec = new TextDecoder();
-      debug(dec.decode(data));
+      debug(dec.decode(data).trim());
 
       // check the OKAY or FAIL on first packet.
       if (waitForFirst) {

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -46,7 +46,7 @@ const RemoteSimulatorClient = Class({
     //       will be called only once)
     //off(this);
 
-    // on pinbackTimeout, emit an high level "timeout" event
+    // on pingbackTimeout, emit a high level "timeout" event
     // and kill the stalled instance
     this.once("pingbackTimeout", function() {
       this._pingbackCompleted = false;
@@ -104,7 +104,11 @@ const RemoteSimulatorClient = Class({
       this._remote = null;
       emit(this, "disconnected", null);
     });
+
+    this.on("stdout", function onStdout(data) console.log(data.trim()));
+    this.on("stderr", function onStderr(data) console.error(data.trim()));
   },
+
   // run({defaultApp: "Appname", pingbackTimeout: 15000})
   // will spawn a b2g instance, optionally run an application
   // and change pingback timeout interval
@@ -152,16 +156,16 @@ const RemoteSimulatorClient = Class({
       command: b2gExecutable,
       arguments: this.b2gArguments,
 
-      // emit stdout messages
+      // emit stdout event
       stdout: (function(data) {
         emit(this, "stdout", data);
       }).bind(this),
-      
-      // emit stdout messages
+
+      // emit stderr event
       stderr: (function(data) {
         emit(this, "stderr", data);
       }).bind(this),
-      
+
       // on b2g instance exit, reset tracked process, remoteDebuggerPort and
       // shuttingDown flag, then finally emit an exit event
       done: (function(result) {       
@@ -244,14 +248,6 @@ const RemoteSimulatorClient = Class({
   getBuildID: function(onResponse) {
     let remote = this._remote;
     remote.client.request({to: remote.simulator, type: "getBuildID"}, onResponse);
-  },
-
-  // send a logStdout request to the remote simulator actor
-  logStdout: function(message, onResponse) {
-    let remote = this._remote;
-    remote.client.request({to: remote.simulator, 
-                           message: message,
-                           type: "logStdout"}, onResponse);
   },
 
   // send a runApp request to the remote simulator actor

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -1023,8 +1023,6 @@ let simulator = module.exports = {
 
     let simulator = this;
     remoteSimulator = new RemoteSimulatorClient({
-      onStdout: function (data) dump(data),
-      onStderr: function (data) dump(data),
       onReady: function () {
         simulator.postIsRunning();
       },

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -83,18 +83,6 @@ SimulatorActor.prototype = {
     };
   },
 
-  onLogStdout: function(aRequest) {
-    dumpn("simulator actor received a 'logStdout' command");
-    // HACK: window.dump should dump on stdout
-    // https://developer.mozilla.org/en/docs/DOM/window.dump#Notes
-    let dumpStdout = this.simulatorWindow.dump;
-    dumpStdout(aRequest.message);
-
-    return {
-      success: true
-    };
-  },
-
   onRunApp: function(aRequest) {
     dumpn("simulator actor received a 'runApp' command:" + aRequest.appId);
     let window = this.simulatorWindow;
@@ -381,7 +369,6 @@ SimulatorActor.prototype = {
 SimulatorActor.prototype.requestTypes = {
   "ping": SimulatorActor.prototype.onPing,
   "getBuildID": SimulatorActor.prototype.onGetBuildID,
-  "logStdout": SimulatorActor.prototype.onLogStdout,
   "runApp": SimulatorActor.prototype.onRunApp,
   "uninstallApp": SimulatorActor.prototype.onUninstallApp,
   "validateManifest": SimulatorActor.prototype.onValidateManifest,

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const DISABLE_DEBUG = true;
-
-let debug = DISABLE_DEBUG ? function () {} : function debugSimulator() {
-  let tag = Components.stack.caller ?
-    (Components.stack.caller.filename + " L" + Components.stack.caller.lineNumber) :
-    "";
-  dump(" -*- " + tag + ": " + Array.slice(arguments).join(" ") + "\n");
+// Override the B2G shell's debug function with a version that concatenates
+// arguments (to simplify outputting certain kinds of messages) and always dumps
+// messages (which the Add-on SDK automatically determines whether to log).
+let debug = function debugSimulator() {
+  dump(Array.slice(arguments).join(" ") + "\n");
 };
 
 document.getElementById("homeButton").addEventListener("mousedown", function() {


### PR DESCRIPTION
This changeset automatically configures prosthesis logging, so prosthesis logs when run on a developer machine (via `make run`, which invokes `cfx run`) but doesn't log when run on a user machine (via installation of a package created by `cfx xpi`).

Primarily, it changes the function used to log B2G stdout from _dump()_ to _console.log()_, which then handles the decision about whether or not to log. But the changeset makes several other changes along the way.
1. Unconditionally enables logging in the simulator actor, so its logging behaves consistently.
2. Removes extra info from prosthesis log messages, like filename and line number. I understand that these can be useful, but they're inconsistent with the messages generated by all other code that logs, including core B2G code, the debugger server (and its actors), and all the modules, including the core SDK modules as well as the main addon's modules. (If it's important to record this information for a particular message, we can still make it do so by using _Cu.reportError()_ or the equivalent.)
3. Moves the logging from Simulator to RemoteSimulatorClient, as this seems more like an internal function of RemoteSimulatorClient.
4. Makes logging in adb.js be consistent with logging elsewhere.
5. Fixes a couple of minor style nits.
6. removes the unused _logStdout_ request type.
