### PR TITLE
FIX: geolocation setup sequence

### DIFF
--- a/prosthesis/components/FakeGeolocationProvider.js
+++ b/prosthesis/components/FakeGeolocationProvider.js
@@ -50,7 +50,7 @@ function FakeGeoPositionProvider() {
       this.callback.update(new FakeGeoPositionObject(
         message.wrappedJSObject.lat, message.wrappedJSObject.lon));
     }
-  }).bind(this), "r2d2b2g-geolocation-response", false);
+  }).bind(this), "r2d2b2g:geolocation-response", false);
 }
 
 FakeGeoPositionProvider.prototype = {
@@ -86,7 +86,7 @@ FakeGeoPositionProvider.prototype = {
   setHighAccuracy: function(enable) {},
 
   walk: function() {
-    Services.obs.notifyObservers(null, "r2d2b2g-geolocation-request", null);
+    Services.obs.notifyObservers(null, "r2d2b2g:geolocation-request", null);
   },
 
   notify: function(timer) {

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -58,8 +58,9 @@ document.getElementById("rotateButton").addEventListener("click", function() {
       gotCoords = function gotCoords(message) {
         latitude = initialLatitude = message.wrappedJSObject.lat;
         longitude = initialLongitude = message.wrappedJSObject.lon;
-        document.getElementById("geolocationButton")
-                .addEventListener("click", openWin);
+      },
+      gotReady = function requestCoords() {
+        Services.obs.notifyObservers(null, "r2d2b2g:geolocation-update", null);
       },
       sendCoords = function sendCoords() {
         Services.obs.notifyObservers({
@@ -67,11 +68,16 @@ document.getElementById("rotateButton").addEventListener("click", function() {
             lat: latitude,
             lon: longitude,
           }
-        }, "r2d2b2g-geolocation-response", null);
+        }, "r2d2b2g:geolocation-response", null);
       };
 
-  Services.obs.addObserver(gotCoords, "r2d2b2g-geolocation-setup", false);
-  Services.obs.addObserver(sendCoords, "r2d2b2g-geolocation-request", false);
+  Services.obs.addObserver(gotReady, "r2d2b2g:geolocation-ready", false);
+  Services.obs.addObserver(gotCoords, "r2d2b2g:geolocation-setup", false);
+  Services.obs.addObserver(sendCoords, "r2d2b2g:geolocation-request", false);
+
+  document.getElementById("geolocationButton")
+          .addEventListener("click", openWin);
+
 }
 
 function simulatorAppUpdate() {


### PR DESCRIPTION
Currently we've 3 sub-issues:
- on nightly, 23.0a1 (2013-04-16), Ci.nsIDOMGeoGeolocation doesn't exist
  (I'm not sure if it could be a temporary problem or a permanent change for
  the future releases)
- if firefox doesn't send a geolocation response, click the button doesn't open
  the geolocation dialog and we can't set a custom location
- our "muted actor due to unsolicited event" workaround doesn't work
  (packets blocked in queue until another unsolicited event will be sent, 
  e.g. appUpdateRequest)

This pull request introduce small changes needed to get simulated geolocation
to work again:
- register geolocation button click listener on start
  to be able to use custom location even if current location response
  will never be received
- remove unsolicited event workaround
- new geolocation setup workflow
  geolocationReady (FIREFOX CLIENT -> B2G ACTOR)
  r2d2b2g:geolocation-ready (B2G ACTOR -> B2G SHELL)
  r2d2b2g:geolocation-update (B2G SHELL -> B2G ACTOR)
  geolocationRequest (B2G ACTOR -> FIREFOX CLIENT)
  geolocationResponse (FIREFOX CLIENT -> B2G ACTOR)
