### PR TITLE
stop retrieving now-unscriptable nsIDOMGeoGeolocation interface from geolocation component

### DIFF
--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -241,7 +241,7 @@ const RemoteSimulatorClient = Class({
       }).bind(this);
 
       let geolocation = Cc["@mozilla.org/geolocation;1"].
-                        getService(Ci.nsIDOMGeoGeolocation);
+                        getService(Ci.nsISupports);
       geolocation.getCurrentPosition(onsuccess, function error() {
         console.error("error getting current position");
       });


### PR DESCRIPTION
[Bug 850442](https://bugzilla.mozilla.org/show_bug.cgi?id=850442) in [part 4 of its changes](http://hg.mozilla.org/mozilla-central/rev/23e907c7c106) made nsIDOMGeoGeolocation nonscriptable, but we can still access the component (and that interface, strangely) by requesting its nsISupports interface instead.
