### PR TITLE
default to custom, not current coordinaates Issue #356

### DIFF
--- a/prosthesis/content/geolocation.js
+++ b/prosthesis/content/geolocation.js
@@ -8,26 +8,25 @@ window.addEventListener("DOMContentLoaded", function() {
       custom = $("custom"),
       latitudeEle = $("latitude"),
       longitudeEle = $("longitude"),
-      inputOutput = window.arguments[0].wrappedJSObject,
-      input = inputOutput.input,
-      output = inputOutput.output,
-      latitude = input.lat,
-      longitude = input.lon,
-      tempUseCurrent = input.useCurrent,
+      windowParams = window.arguments[0].wrappedJSObject,
+      latitude = windowParams.lat,
+      longitude = windowParams.lon,
+      tempUseCurrent = windowParams.useCurrent,
       setTextBoxes = function(disabled) {
         latitudeEle.disabled = disabled;
         longitudeEle.disabled = disabled;
         tempUseCurrent = disabled;
       },
       accept = function () {
-        output.lat = latitudeEle.value;
-        output.lon = longitudeEle.value;
-        output.useCurrent = tempUseCurrent;
+        windowParams.lat = latitudeEle.value;
+        windowParams.lon = longitudeEle.value;
+        windowParams.useCurrent = tempUseCurrent;
         window.close();
       };
 
-  setTextBoxes(input.useCurrent);
-  custom.parentElement.selectedItem = input.useCurrent ? current : custom;
+  setTextBoxes(windowParams.useCurrent);
+  custom.parentElement.selectedItem =
+    windowParams.useCurrent ? current : custom;
   latitudeEle.value = latitude;
   longitudeEle.value = longitude;
 

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -29,15 +29,16 @@ document.getElementById("rotateButton").addEventListener("click", function() {
 }, false);
 
 {
-  let initialLatitude = 0,
-      initialLongitude = 0,
+  let currentLatitude = 0,
+      currentLongitude = 0,
       latitude = 0,
       longitude = 0,
-      useCurrent = true,
+      useCurrent = false,
       openWin = function openWin() {
         let params = {
-          input: { lat: latitude, lon: longitude, useCurrent: useCurrent },
-          output: { lat: null, lon: null, useCurrent: useCurrent }
+          lat: latitude,
+          lon: longitude,
+          useCurrent: useCurrent
         };
 
         Services.ww.openWindow(null,
@@ -46,18 +47,18 @@ document.getElementById("rotateButton").addEventListener("click", function() {
           "chrome,dialog,menubar,centerscreen,modal",
           { wrappedJSObject: params });
 
-        useCurrent = params.output.useCurrent;
+        useCurrent = params.useCurrent;
         if (useCurrent) {
-          latitude = initialLatitude;
-          longitude = initialLongitude;
+          latitude = currentLatitude;
+          longitude = currentLongitude;
         } else {
-          latitude = params.output.lat || latitude;
-          longitude = params.output.lon || longitude;
+          latitude = params.lat || latitude;
+          longitude = params.lon || longitude;
         }
       },
       gotCoords = function gotCoords(message) {
-        latitude = initialLatitude = message.wrappedJSObject.lat;
-        longitude = initialLongitude = message.wrappedJSObject.lon;
+        currentLatitude = message.wrappedJSObject.lat;
+        currentLongitude = message.wrappedJSObject.lon;
       },
       gotReady = function requestCoords() {
         Services.obs.notifyObservers(null, "r2d2b2g:geolocation-update", null);


### PR DESCRIPTION
Myk, I wanted to bang out Issue #356.  This patch will default to custom coordinates (0, 0) instead of current coordinates.  I want to finish this up in Issue #357, by not actually getting the current position until it's requested from the Firefox process.  If you agree and this patch looks good, please close Issue #356 after merging this.
