### PR TITLE
Issue #448: Disable worker when the Simulator is hidden in history and ensure that we load only one Simulator page.

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -27,8 +27,15 @@ PageMod({
   contentScriptFile: Simulator.contentScript,
   contentScriptWhen: 'start',
   onAttach: function(worker) {
-    // TODO: Only allow 1 manager page
-    Simulator.worker = worker;
+    // Ignore tentatives to open multiple simulator page
+    // by showing the tab with existing instance
+    if (Simulator.worker) {
+      Simulator.worker.tab.activate();
+      worker.tab.close();
+    }
+    else {
+      Simulator.worker = worker;
+    }
   },
 });
 

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -113,9 +113,15 @@ let simulator = module.exports = {
 
     if (worker) {
       worker.on("message", this.onMessage.bind(this));
-      worker.on("detach", (function(message) {
+      worker.on("detach", function(message) {
         worker = null;
-      }).bind(this));
+      });
+      worker.on("pageshow", function(message) {
+        worker = this;
+      });
+      worker.on("pagehide", function(message) {
+        worker = null;
+      });
 
       if (!ADB.ready) {
         ADB.start();
@@ -890,7 +896,11 @@ let simulator = module.exports = {
   },
 
   openHelperTab: function() {
-    this.openTab(simulator.contentPage, true);
+    // Ensure opening only one simulator page
+    if (this.worker)
+      this.worker.tab.activate();
+    else
+      this.openTab(simulator.contentPage, true);
   },
 
   closeHelperTab: function closeHelperTab() {


### PR DESCRIPTION
Followup of #448. I'm not sure how much nullication of worker when the simulator disappear in history is going to help, but I tried to avoid cases where we open simulator page multiple times. It should definitely kill some weirdness if a user was opening mutliples...
