### PR TITLE
Issue #196: Prevent horizontal resize and prevent smaller vertical one.

### DIFF
--- a/prosthesis/content/window-manager.js
+++ b/prosthesis/content/window-manager.js
@@ -15,6 +15,8 @@ let SimulatorWindowManager = {
     this._initObservers();
     this._initKeepWindowSize();
     this._initMutationObservers();
+    this._adjustWindowSize(GlobalSimulatorScreen.width,
+                           GlobalSimulatorScreen.height);
   },
   get _homescreen() shell.contentBrowser.contentWindow.wrappedJSObject,
   get _shellElement() document.getElementById("shell"),


### PR DESCRIPTION
I also tried toolkit.defaultChromeFeatures and various other things, but there almost nothing works to prevent resize :/
I wasn't able to prevent all kind of resize, but with this simple patch, only one kind of resize is still possible: you can get a bigger vertical size.
