### PR TITLE
remove skin provider

### DIFF
--- a/prosthesis/chrome.manifest
+++ b/prosthesis/chrome.manifest
@@ -2,7 +2,6 @@ resource prosthesis ./
 
 content prosthesis content/
 locale prosthesis en-US locale/en-US/
-skin prosthesis skin skin/
 
 # B2G's "content" stylesheet removes styles from a variety of XUL widgets we use
 # in parts of the Simulator interface, making them hard to recognize, so we


### PR DESCRIPTION
@ochameau: One more thing! Now that we don't have a prosthesis/skin/ directory, we don't need a skin provider, so here's a change that removes its chrome.manifest instruction.
