### PR TITLE
merge adb stdout/stderr to work around subprocess bug (fixes #460)

### DIFF
--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -122,13 +122,16 @@ this.ADB = {
     subprocess.call({
       command: this._adb.path,
 
+      // Merge stderr into stdout to work around a subprocess bug in which
+      // it doesn't notice that stdout and stderr have both closed after
+      // the process exits, so it never calls our 'done' handler.  Since all
+      // we do is dump both output streams to a debug log, it doesn't matter
+      // that we merge them.
+      mergeStderr: true,
+
       arguments: ["start-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
         debug(data.trim());
       },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -164,13 +164,16 @@ this.ADB = {
     let process = subprocess.call({
       command: this._adb.path,
 
+      // Merge stderr into stdout to work around a subprocess bug in which
+      // it doesn't notice that stdout and stderr have both closed after
+      // the process exits, so it never calls our 'done' handler.  Since all
+      // we do is dump both output streams to a debug log, it doesn't matter
+      // that we merge them.
+      mergeStderr: true,
+
       arguments: ["kill-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
         debug(data.trim());
       },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -125,15 +125,15 @@ this.ADB = {
       arguments: ["start-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug("stdout: " + data);
+        debug(data.trim());
       },
 
       stderr: function adb_start_stderr(data) {
-        debug("stderr: " + data);
+        debug(data.trim());
       },
 
       done: function adb_start_done(result) {
-        debug("start-server exit code: " + result.exitCode);
+        debug("start-server done: " + result.exitCode);
         if (result.exitCode == 0) {
           Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
           self.ready = true;
@@ -164,15 +164,15 @@ this.ADB = {
       arguments: ["kill-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug("kill-server stdout: " + data);
+        debug(data.trim());
       },
 
       stderr: function adb_start_stderr(data) {
-        debug("kill-server stderr: " + data);
+        debug(data.trim());
       },
 
       done: function adb_start_done(result) {
-        debug("kill-server exit code: " + result.exitCode);
+        debug("kill-server done: " + result.exitCode);
         if (result.exitCode == 0) {
           self.ready = false;
           Services.obs.notifyObservers(null, "adb-killed", null);

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -23,13 +23,6 @@ let Cu = components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
-let subprocess;
-if (COMMONJS) {
-  subprocess = require("subprocess");
-} else {
-  Cu.import("chrome://b2g-remote/content/subprocess.jsm");
-}
-
 // Get the TextEncoder and TextDecoder interfaces from the hidden window,
 // since they aren't defined in a CommonJS module by default.
 let hiddenWindow = Cc['@mozilla.org/appshell/appShellService;1']
@@ -117,35 +110,25 @@ this.ADB = {
   // We startup by launching adb in server mode, and setting
   // the tcp socket preference to |true|
   start: function adb_start() {
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["start-server"];
     let self = this;
-
-    subprocess.call({
-      command: this._adb.path,
-
-      // Merge stderr into stdout to work around a subprocess bug in which
-      // it doesn't notice that stdout and stderr have both closed after
-      // the process exits, so it never calls our 'done' handler.  Since all
-      // we do is dump both output streams to a debug log, it doesn't matter
-      // that we merge them.
-      mergeStderr: true,
-
-      arguments: ["start-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("start-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
-          self.ready = true;
-          Services.obs.notifyObservers(null, "adb-ready", null);
-        } else {
-          self.ready = false;
-        }
-      }
-    });
+    process.runAsync(params, params.length, {
+      observe: function(aSubject, aTopic, aData) {
+        switch(aTopic) {
+          case "process-finished":
+            Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
+            Services.obs.notifyObservers(null, "adb-ready", null);
+            self.ready = true;
+            break;
+          case "process-failed":
+            self.ready = false;
+            break;
+         }
+       }
+    }, false);
   },
 
   /**
@@ -161,44 +144,37 @@ this.ADB = {
    *        the update doesn't race the killing.
    */
   kill: function adb_kill(aSync) {
-    let process = subprocess.call({
-      command: this._adb.path,
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["kill-server"];
 
-      // Merge stderr into stdout to work around a subprocess bug in which
-      // it doesn't notice that stdout and stderr have both closed after
-      // the process exits, so it never calls our 'done' handler.  Since all
-      // we do is dump both output streams to a debug log, it doesn't matter
-      // that we merge them.
-      mergeStderr: true,
-
-      arguments: ["kill-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("kill-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else if (result.exitCode == 1) {
-          // This is a known problem.  For some reason, adb kill-server
-          // frequently writes "* server not running *" and exits with code 1
-          // even though the server process was running, and it killed it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else {
-          // It's hard to say whether or not ADB is ready at this point,
-          // but it seems safer to assume that it isn't, so code that wants
-          // to use it later will try to restart it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        }
-      }
-    });
     if (aSync) {
-      process.wait();
+      process.run(true, params, params.length);
+      debug("adb kill-server: " + process.exitValue);
+      this.ready = false;
+    }
+    else {
+      let self = this;
+      process.runAsync(params, params.length, {
+        observe: function(aSubject, aTopic, aData) {
+          switch(aTopic) {
+            case "process-finished":
+              debug("adb kill-server: " + process.exitValue);
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+            case "process-failed":
+              debug("adb kill-server failure: " + process.exitValue);
+              // It's hard to say whether or not ADB is ready at this point,
+              // but it seems safer to assume that it isn't, so code that wants
+              // to use it later will try to restart it.
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+          }
+        }
+      }, false);
     }
   },
 

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -15,7 +15,6 @@ const Runtime = require("runtime");
 const Self = require("self");
 const URL = require("url");
 const Subprocess = require("subprocess");
-
 const Prefs = require("preferences-service");
 
 const { rootURI: ROOT_URI } = require('@loader/options');

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -30,9 +30,9 @@ dbgClient.UnsolicitedNotifications.geolocationRequest = "geolocationRequest";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
 
 // Log subprocess error and debug messages to the console.  This logs messages
-// for all consumers of the API, including the ADB module.  We trim the messages
-// because they sometimes have trailing newlines.  And note that
-// registerLogHandler actually registers an error handler, despite its name.
+// for all consumers of the API.  We trim the messages because they sometimes
+// have trailing newlines.  And note that registerLogHandler actually registers
+// an error handler, despite its name.
 Subprocess.registerLogHandler(
   function(s) console.error("subprocess: " + s.trim())
 );

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -15,6 +15,7 @@ const Runtime = require("runtime");
 const Self = require("self");
 const URL = require("url");
 const Subprocess = require("subprocess");
+
 const Prefs = require("preferences-service");
 
 const { rootURI: ROOT_URI } = require('@loader/options');
@@ -28,6 +29,17 @@ const dbgClient = Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 // add an unsolicited notification for geolocation
 dbgClient.UnsolicitedNotifications.geolocationRequest = "geolocationRequest";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
+
+// Log subprocess error and debug messages to the console.  This logs messages
+// for all consumers of the API, including the ADB module.  We trim the messages
+// because they sometimes have trailing newlines.  And note that
+// registerLogHandler actually registers an error handler, despite its name.
+Subprocess.registerLogHandler(
+  function(s) console.error("subprocess: " + s.trim())
+);
+Subprocess.registerDebugHandler(
+  function(s) console.debug("subprocess: " + s.trim())
+);
 
 const RemoteSimulatorClient = Class({
   extends: EventTarget,

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -65,12 +65,8 @@ let simulator = module.exports = {
     // unnecessarily if the user is quitting Firefox or disabling the addon;
     // and so they close their filehandles if the user is updating the addon,
     // which we need to do on Windows to replace the files.
-    this.kill(function() {
-      // We wait until the Simulator process is dead before starting the process
-      // that kills the ADB server because Firefox was crashing or hanging when
-      // we did those two things simultaneously (issue #435).
-      ADB.kill(Runtime.OS == "WINNT" ? true : false /* sync */);
-    });
+    this.kill();
+    ADB.kill(Runtime.OS == "WINNT" ? true : false /* sync */);
 
     // Close the Dashboard if the user is disabling or updating the addon.
     // We don't close it if the user is quitting Firefox because we want it


### PR DESCRIPTION
This change merges the stdout/stderr streams for the adb subprocess calls to work around a subprocess bug in which subprocess doesn't notice that one of the streams has closed after the subprocess exits, so it never calls its _done_ handler, and the adb module never starts tracking devices.

I see the problem consistently the first time adb is invoked to start the server with `adb start-server`, which actually starts the server; but not the second time, which doesn't start the server because the server is already started (hence issue #460).

This pull also includes a few improvements to adb/subprocess logging.
