### PR TITLE
update adb's use of nsIDOMTCPSocket to work with recent Nightly builds

### DIFF
--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -122,13 +122,16 @@ this.ADB = {
     subprocess.call({
       command: this._adb.path,
 
+      // Merge stderr into stdout to work around a subprocess bug in which
+      // it doesn't notice that stdout and stderr have both closed after
+      // the process exits, so it never calls our 'done' handler.  Since all
+      // we do is dump both output streams to a debug log, it doesn't matter
+      // that we merge them.
+      mergeStderr: true,
+
       arguments: ["start-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
         debug(data.trim());
       },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -523,11 +523,9 @@ this.ADB = {
           }
 
           // Ending up with DONE + mtime (wtf???)
-          let done = encoder.encode("DONE");
-          socket.send(done.buffer, done.byteOffset, done.byteLength);
+          ADB.sockSend(socket, encoder.encode("DONE"));
           uint32Packet[0] = fileTime;
-          socket.send(uint8Packet.buffer, uint8Packet.byteOffset,
-                      uint8Packet.byteLength);
+          ADB.sockSend(socket, uint8Packet);
           state = "wait-done";
           break;
         case "wait-done":

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -164,13 +164,16 @@ this.ADB = {
     let process = subprocess.call({
       command: this._adb.path,
 
+      // Merge stderr into stdout to work around a subprocess bug in which
+      // it doesn't notice that stdout and stderr have both closed after
+      // the process exits, so it never calls our 'done' handler.  Since all
+      // we do is dump both output streams to a debug log, it doesn't matter
+      // that we merge them.
+      mergeStderr: true,
+
       arguments: ["kill-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      stderr: function adb_start_stderr(data) {
         debug(data.trim());
       },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -438,7 +438,6 @@ this.ADB = {
       }
     }
     debug(dbg);
-    debug("byteOffset: " + aArray.byteOffset + "; byteLength: " + aArray.byteLength);
     aSocket.send(aArray.buffer, aArray.byteOffset, aArray.byteLength);
   },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -23,13 +23,6 @@ let Cu = components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
-let subprocess;
-if (COMMONJS) {
-  subprocess = require("subprocess");
-} else {
-  Cu.import("chrome://b2g-remote/content/subprocess.jsm");
-}
-
 // Get the TextEncoder and TextDecoder interfaces from the hidden window,
 // since they aren't defined in a CommonJS module by default.
 let hiddenWindow = Cc['@mozilla.org/appshell/appShellService;1']
@@ -117,32 +110,25 @@ this.ADB = {
   // We startup by launching adb in server mode, and setting
   // the tcp socket preference to |true|
   start: function adb_start() {
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["start-server"];
     let self = this;
-
-    subprocess.call({
-      command: this._adb.path,
-
-      arguments: ["start-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug("stdout: " + data);
-      },
-
-      stderr: function adb_start_stderr(data) {
-        debug("stderr: " + data);
-      },
-
-      done: function adb_start_done(result) {
-        debug("start-server exit code: " + result.exitCode);
-        if (result.exitCode == 0) {
-          Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
-          self.ready = true;
-          Services.obs.notifyObservers(null, "adb-ready", null);
-        } else {
-          self.ready = false;
-        }
-      }
-    });
+    process.runAsync(params, params.length, {
+      observe: function(aSubject, aTopic, aData) {
+        switch(aTopic) {
+          case "process-finished":
+            Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
+            Services.obs.notifyObservers(null, "adb-ready", null);
+            self.ready = true;
+            break;
+          case "process-failed":
+            self.ready = false;
+            break;
+         }
+       }
+    }, false);
   },
 
   /**
@@ -158,41 +144,37 @@ this.ADB = {
    *        the update doesn't race the killing.
    */
   kill: function adb_kill(aSync) {
-    let process = subprocess.call({
-      command: this._adb.path,
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["kill-server"];
 
-      arguments: ["kill-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug("kill-server stdout: " + data);
-      },
-
-      stderr: function adb_start_stderr(data) {
-        debug("kill-server stderr: " + data);
-      },
-
-      done: function adb_start_done(result) {
-        debug("kill-server exit code: " + result.exitCode);
-        if (result.exitCode == 0) {
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else if (result.exitCode == 1) {
-          // This is a known problem.  For some reason, adb kill-server
-          // frequently writes "* server not running *" and exits with code 1
-          // even though the server process was running, and it killed it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else {
-          // It's hard to say whether or not ADB is ready at this point,
-          // but it seems safer to assume that it isn't, so code that wants
-          // to use it later will try to restart it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        }
-      }
-    });
     if (aSync) {
-      process.wait();
+      process.run(true, params, params.length);
+      debug("adb kill-server: " + process.exitValue);
+      this.ready = false;
+    }
+    else {
+      let self = this;
+      process.runAsync(params, params.length, {
+        observe: function(aSubject, aTopic, aData) {
+          switch(aTopic) {
+            case "process-finished":
+              debug("adb kill-server: " + process.exitValue);
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+            case "process-failed":
+              debug("adb kill-server failure: " + process.exitValue);
+              // It's hard to say whether or not ADB is ready at this point,
+              // but it seems safer to assume that it isn't, so code that wants
+              // to use it later will try to restart it.
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+          }
+        }
+      }, false);
     }
   },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -125,15 +125,15 @@ this.ADB = {
       arguments: ["start-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug("stdout: " + data);
+        debug(data.trim());
       },
 
       stderr: function adb_start_stderr(data) {
-        debug("stderr: " + data);
+        debug(data.trim());
       },
 
       done: function adb_start_done(result) {
-        debug("start-server exit code: " + result.exitCode);
+        debug("start-server done: " + result.exitCode);
         if (result.exitCode == 0) {
           Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
           self.ready = true;
@@ -164,15 +164,15 @@ this.ADB = {
       arguments: ["kill-server"],
 
       stdout: function adb_start_stdout(data) {
-        debug("kill-server stdout: " + data);
+        debug(data.trim());
       },
 
       stderr: function adb_start_stderr(data) {
-        debug("kill-server stderr: " + data);
+        debug(data.trim());
       },
 
       done: function adb_start_done(result) {
-        debug("kill-server exit code: " + result.exitCode);
+        debug("kill-server done: " + result.exitCode);
         if (result.exitCode == 0) {
           self.ready = false;
           Services.obs.notifyObservers(null, "adb-killed", null);

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -396,30 +396,35 @@ this.ADB = {
     return deferred.promise;
   },
 
-  // debugging version of tcpsocket.send()
-  sockSend: function adb_sockSend(aSocket, aArray) {
-    let decoder = new TextDecoder();
-    let s = decoder.decode(aArray);
-    let len = aArray.length;
+  stringify: function adb_stringify(aBuffer) {
+    let decoder = new TextDecoder("windows-1252");
+    let array = new Uint8Array(aBuffer);
+    let s = decoder.decode(array);
+    let len = array.length;
     let dbg = "len=" + len + " ";
-    let l = len > 20 ? 20 : len;
+    let l = len > 255 ? 255 : len;
 
     for (let i = 0; i < l; i++) {
-      let c = aArray[i].toString(16);
+      let c = array[i].toString(16);
       if (c.length == 1)
         c = "0" + c;
       dbg += c;
     }
     dbg += " ";
     for (let i = 0; i < l; i++) {
-      let c = aArray[i];
+      let c = array[i];
       if (c < 32 || c > 127) {
         dbg += ".";
       } else {
         dbg += s[i];
       }
     }
-    debug(dbg);
+    return dbg;
+  },
+
+  // debugging version of tcpsocket.send()
+  sockSend: function adb_sockSend(aSocket, aArray) {
+    debug(this.stringify(aArray.buffer));
     aSocket.send(aArray.buffer, aArray.byteOffset, aArray.byteLength);
   },
 

--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -23,13 +23,6 @@ let Cu = components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
-let subprocess;
-if (COMMONJS) {
-  subprocess = require("subprocess");
-} else {
-  Cu.import("chrome://b2g-remote/content/subprocess.jsm");
-}
-
 // Get the TextEncoder and TextDecoder interfaces from the hidden window,
 // since they aren't defined in a CommonJS module by default.
 let hiddenWindow = Cc['@mozilla.org/appshell/appShellService;1']
@@ -117,35 +110,25 @@ this.ADB = {
   // We startup by launching adb in server mode, and setting
   // the tcp socket preference to |true|
   start: function adb_start() {
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["start-server"];
     let self = this;
-
-    subprocess.call({
-      command: this._adb.path,
-
-      // Merge stderr into stdout to work around a subprocess bug in which
-      // it doesn't notice that stdout and stderr have both closed after
-      // the process exits, so it never calls our 'done' handler.  Since all
-      // we do is dump both output streams to a debug log, it doesn't matter
-      // that we merge them.
-      mergeStderr: true,
-
-      arguments: ["start-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("start-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
-          self.ready = true;
-          Services.obs.notifyObservers(null, "adb-ready", null);
-        } else {
-          self.ready = false;
-        }
-      }
-    });
+    process.runAsync(params, params.length, {
+      observe: function(aSubject, aTopic, aData) {
+        switch(aTopic) {
+          case "process-finished":
+            Services.prefs.setBoolPref("dom.mozTCPSocket.enabled", true);
+            Services.obs.notifyObservers(null, "adb-ready", null);
+            self.ready = true;
+            break;
+          case "process-failed":
+            self.ready = false;
+            break;
+         }
+       }
+    }, false);
   },
 
   /**
@@ -161,44 +144,37 @@ this.ADB = {
    *        the update doesn't race the killing.
    */
   kill: function adb_kill(aSync) {
-    let process = subprocess.call({
-      command: this._adb.path,
+    let process = Cc["@mozilla.org/process/util;1"]
+                    .createInstance(Ci.nsIProcess);
+    process.init(this._adb);
+    let params = ["kill-server"];
 
-      // Merge stderr into stdout to work around a subprocess bug in which
-      // it doesn't notice that stdout and stderr have both closed after
-      // the process exits, so it never calls our 'done' handler.  Since all
-      // we do is dump both output streams to a debug log, it doesn't matter
-      // that we merge them.
-      mergeStderr: true,
-
-      arguments: ["kill-server"],
-
-      stdout: function adb_start_stdout(data) {
-        debug(data.trim());
-      },
-
-      done: function adb_start_done(result) {
-        debug("kill-server done: " + result.exitCode);
-        if (result.exitCode == 0) {
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else if (result.exitCode == 1) {
-          // This is a known problem.  For some reason, adb kill-server
-          // frequently writes "* server not running *" and exits with code 1
-          // even though the server process was running, and it killed it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        } else {
-          // It's hard to say whether or not ADB is ready at this point,
-          // but it seems safer to assume that it isn't, so code that wants
-          // to use it later will try to restart it.
-          self.ready = false;
-          Services.obs.notifyObservers(null, "adb-killed", null);
-        }
-      }
-    });
     if (aSync) {
-      process.wait();
+      process.run(true, params, params.length);
+      debug("adb kill-server: " + process.exitValue);
+      this.ready = false;
+    }
+    else {
+      let self = this;
+      process.runAsync(params, params.length, {
+        observe: function(aSubject, aTopic, aData) {
+          switch(aTopic) {
+            case "process-finished":
+              debug("adb kill-server: " + process.exitValue);
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+            case "process-failed":
+              debug("adb kill-server failure: " + process.exitValue);
+              // It's hard to say whether or not ADB is ready at this point,
+              // but it seems safer to assume that it isn't, so code that wants
+              // to use it later will try to restart it.
+              Services.obs.notifyObservers(null, "adb-killed", null);
+              self.ready = false;
+              break;
+          }
+        }
+      }, false);
     }
   },
 

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -15,7 +15,6 @@ const Runtime = require("runtime");
 const Self = require("self");
 const URL = require("url");
 const Subprocess = require("subprocess");
-
 const Prefs = require("preferences-service");
 
 const { rootURI: ROOT_URI } = require('@loader/options');

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -30,9 +30,9 @@ dbgClient.UnsolicitedNotifications.geolocationRequest = "geolocationRequest";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
 
 // Log subprocess error and debug messages to the console.  This logs messages
-// for all consumers of the API, including the ADB module.  We trim the messages
-// because they sometimes have trailing newlines.  And note that
-// registerLogHandler actually registers an error handler, despite its name.
+// for all consumers of the API.  We trim the messages because they sometimes
+// have trailing newlines.  And note that registerLogHandler actually registers
+// an error handler, despite its name.
 Subprocess.registerLogHandler(
   function(s) console.error("subprocess: " + s.trim())
 );

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -15,6 +15,7 @@ const Runtime = require("runtime");
 const Self = require("self");
 const URL = require("url");
 const Subprocess = require("subprocess");
+
 const Prefs = require("preferences-service");
 
 const { rootURI: ROOT_URI } = require('@loader/options');
@@ -28,6 +29,17 @@ const dbgClient = Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 // add an unsolicited notification for geolocation
 dbgClient.UnsolicitedNotifications.geolocationRequest = "geolocationRequest";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
+
+// Log subprocess error and debug messages to the console.  This logs messages
+// for all consumers of the API, including the ADB module.  We trim the messages
+// because they sometimes have trailing newlines.  And note that
+// registerLogHandler actually registers an error handler, despite its name.
+Subprocess.registerLogHandler(
+  function(s) console.error("subprocess: " + s.trim())
+);
+Subprocess.registerDebugHandler(
+  function(s) console.debug("subprocess: " + s.trim())
+);
 
 const RemoteSimulatorClient = Class({
   extends: EventTarget,

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -65,12 +65,8 @@ let simulator = module.exports = {
     // unnecessarily if the user is quitting Firefox or disabling the addon;
     // and so they close their filehandles if the user is updating the addon,
     // which we need to do on Windows to replace the files.
-    this.kill(function() {
-      // We wait until the Simulator process is dead before starting the process
-      // that kills the ADB server because Firefox was crashing or hanging when
-      // we did those two things simultaneously (issue #435).
-      ADB.kill(Runtime.OS == "WINNT" ? true : false /* sync */);
-    });
+    this.kill();
+    ADB.kill(Runtime.OS == "WINNT" ? true : false /* sync */);
 
     // Close the Dashboard if the user is disabling or updating the addon.
     // We don't close it if the user is quitting Firefox because we want it


### PR DESCRIPTION
@ochameau: this is what I have so far, and it finds devices just fine (modulo other issues like #460), but push to device fails:

```
info: r2d2b2g: adb: pushing /Users/myk/Library/Caches/TemporaryItems/b2g/68bc7877-2192-854c-a47c-daebcff7e3f0/manifest.webapp -> /data/local/tmp/b2g/68bc7877-2192-854c-a47c-daebcff7e3f0/manifest.webapp
info: r2d2b2g: adb: /Users/myk/Library/Caches/TemporaryItems/b2g/68bc7877-2192-854c-a47c-daebcff7e3f0/manifest.webapp size is 669
info: r2d2b2g: adb: push onopen
info: r2d2b2g: adb: runFSM start
info: r2d2b2g: adb: runFSM send-transport
info: r2d2b2g: adb: push ondata
info: r2d2b2g: adb: runFSM wait-transport
info: r2d2b2g: adb: transport: OK
info: r2d2b2g: adb: runFSM send-sync
info: r2d2b2g: adb: push ondata
info: r2d2b2g: adb: runFSM wait-sync
info: r2d2b2g: adb: sync: OK
info: r2d2b2g: adb: runFSM send-send
info: r2d2b2g: adb: len=4 53454e44 SEND
info: r2d2b2g: adb: len=4 4e000000 N...
info: r2d2b2g: adb: len=78 2f646174612f6c6f63616c2f746d702f6232672f /data/local/tmp/b2g/
info: r2d2b2g: adb: Sending 669 bytes
info: r2d2b2g: adb: len=4 44415441 DATA
info: r2d2b2g: adb: len=4 9d020000 ....
info: r2d2b2g: adb: len=669 7b0a2020226e616d65223a20224d796b7a696c6c {.  "name": "Mykzill
info: r2d2b2g: adb: push ondata
info: r2d2b2g: adb: runFSM wait-done
info: r2d2b2g: adb: Response: FAIL
info: r2d2b2g: adb: push shutdown
error: r2d2b2g: ADB.push manifest file error: BAD_RESPONSE
info: r2d2b2g: adb: push onclose
```
