### PR TITLE
match hashes at the end of our contentPage.

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -23,7 +23,7 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
 PageMod({
-  include: Simulator.contentPage,
+  include: Simulator.contentPage + '*', //ensure we match hashes (#)
   contentScriptFile: Simulator.contentScript,
   contentScriptWhen: 'start',
   onAttach: function(worker) {

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -127,7 +127,7 @@ let simulator = module.exports = {
     }
   },
 
-  get contentPage() Self.data.url("content/index.html"),
+  get contentPage() Self.data.url("content/index.html*"),
 
   get contentScript() Self.data.url("content-script.js"),
 

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -127,7 +127,7 @@ let simulator = module.exports = {
     }
   },
 
-  get contentPage() Self.data.url("content/index.html*"),
+  get contentPage() Self.data.url("content/index.html"),
 
   get contentScript() Self.data.url("content-script.js"),
 


### PR DESCRIPTION
&hellip;otherwise, restored simulator pages may not attach to the worker properly.
