### PR TITLE
Trim URLs when adding manifests/websites

### DIFF
--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -57,7 +57,7 @@ var Simulator = {
       var valid = input[0].checkValidity();
       window.postMessage({
         name: "addAppByTab",
-        url: input.val()
+        url: input.val().trim()
       }, "*");
       $("#form-add-app").get(0).reset();
     });


### PR DESCRIPTION
After having the issue the 5th time, I found that this low risk fix for #178 is making the Simulator UX for adding URLs at least 20% better.
