### PR TITLE
Fix rotate button background when active/inactive.

### DIFF
--- a/prosthesis/content/shell.css
+++ b/prosthesis/content/shell.css
@@ -25,11 +25,11 @@ toolbarbutton > .toolbarbutton-text {
 
 #rotateButton {
   list-style-image: url("chrome://prosthesis/content/icons/rotate.png");
-  -moz-image-region: rect(0, 36px, 12px, 24px);
+  -moz-image-region: rect(0, 24px, 12px, 12px);
 }
 
 #rotateButton.active {
-  -moz-image-region: rect(0, 24px, 12px, 12px);
+  -moz-image-region: rect(0, 36px, 12px, 24px);
 }
 
 #rotateButton.active:hover {


### PR DESCRIPTION
I thought that rotate button was just broken and it took me some time to understand that rotation is possible only when being in some apps.
Currently the rotate button has inversed colors. Gray for active and black for inactive.
Fixing the color already helps comprehesion, but it may be usefull to also add a tooltip or a warning.
