### PR TITLE
make tests work again and simplify/conventionalize them

### DIFF
--- a/addon/test/test-remote-simulator-client.js
+++ b/addon/test/test-remote-simulator-client.js
@@ -13,7 +13,7 @@ exports["test RemoteSimulatorClient run/ping/kill"] = function(assert, done) {
       assert.pass("simulator ready");
       rsc.ping(
         function onResponse(response) {
-          assert.ok(response.msg == "pong", "ping response is pong");
+          assert.equal(response.msg, "pong", "ping response is pong");
           rsc.kill();
         }
       );

--- a/addon/test/test-remote-simulator-client.js
+++ b/addon/test/test-remote-simulator-client.js
@@ -7,9 +7,6 @@
 const RemoteSimulatorClient = require("remote-simulator-client");
 
 exports["test:RemoteSimulatorClient run/onReady/onStdout/onExit"] = function(test, done) {
-  // WORKAROUND: random timeouts on Mac
-  test._log.waitUntilDone(30000);
-
   var timeout = false;
   var stdout = false;
   var rsc = new RemoteSimulatorClient({


### PR DESCRIPTION
This makes tests work again and also simplifies them to the extent possible and makes them use a conventional structure and style like the more recent tests in the Add-on SDK.
