### PR TITLE
Ignore eventual previous b2g desktop zombie instances.

### DIFF
--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -178,7 +178,7 @@ const RemoteSimulatorClient = Class({
 
       // on b2g instance exit, reset tracked process, remoteDebuggerPort and
       // shuttingDown flag, then finally emit an exit event
-      done: (function(result) {       
+      done: (function(result) {
         console.log(this.b2gFilename + " terminated with " + result.exitCode);
         this.process = null;
         // NOTE: reset old allocated remoteDebuggerPort
@@ -402,6 +402,9 @@ const RemoteSimulatorClient = Class({
     if (this._defaultApp != null) {
       args.push("--runapp", this._defaultApp);
     }
+
+    // Ignore eventual zombie instances of b2g that are left over
+    args.push("-no-remote");
 
     return args;
   },


### PR DESCRIPTION
Fixes the issue described here: https://github.com/mozilla/r2d2b2g/pull/488#issuecomment-17507891

When something goes wrong on we leave a b2g instance alive, the next try to run b2g will fail. The b2g app window will stay black, or, when we ask for the console, only the console shows up.
That's because the new b2g instance will connect to the previous one and immediatly quit.

We should use `-no-remote` to prevent this.
