### PR TITLE
Start using gaia's desktop helper to fix touch events and gain API mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,10 @@ clean:
 profile:
 	cp build/override-prefs.js gaia/build/custom-prefs.js
 	cp build/override-settings.json gaia/build/custom-settings.json
-	NOFTU=1 GAIA_APP_SRCDIRS=apps make -C gaia
+	NOFTU=1 BROWSER=1 GAIA_APP_SRCDIRS=apps make -C gaia
 	python build/override-webapps.py
+	cd gaia/profile/extensions/desktop-helper/ && zip -r ../desktop-helper\@gaiamobile.org.xpi *
+	cd gaia/profile/extensions/activities/ && zip -r ../activities\@gaiamobile.org.xpi *
 	rm -rf gaia/profile/startupCache
 	rm -rf addon/template
 	mkdir -p addon/template

--- a/build/override-prefs.js
+++ b/build/override-prefs.js
@@ -1,1 +1,0 @@
-user_pref("dom.w3c_touch_events.enabled", 0);


### PR DESCRIPTION
By using desktop helper, we will be able to fix touch events and also share API mocks available here:
https://github.com/mozilla-b2g/gaia/tree/master/tools/extensions/desktop-helper/content/data/lib

This patch depends on gaia modification from https://bugzilla.mozilla.org/show_bug.cgi?id=869540.
