### PR TITLE
clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,9 @@ adb:
 	mkdir -p addon/data/$(B2G_PLATFORM)
 	cd addon/data/$(B2G_PLATFORM) && rm -rf adb $(ADB_BINARIES)
 	mkdir addon/data/$(B2G_PLATFORM)/adb
-	$(DOWNLOAD_CMD) $(ADB_URL)
+	if [ ! -f $(ADB_PACKAGE) ]; then \
+	  $(DOWNLOAD_CMD) $(ADB_URL); \
+	fi;
 	unzip $(ADB_PACKAGE) -d addon/data/$(B2G_PLATFORM)/adb
 
 locales:

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ profile:
 	cp addon-sdk/app-extension/bootstrap.js addon/template/
 	cp addon-sdk/app-extension/install.rdf addon/template/
 	mkdir -p addon/template/profile/extensions
-	cd prosthesis && zip -r b2g-prosthesis\@mozilla.org.xpi content components defaults locale modules skin chrome.manifest install.rdf
+	cd prosthesis && zip -r b2g-prosthesis\@mozilla.org.xpi content components defaults locale modules chrome.manifest install.rdf
 	mv prosthesis/b2g-prosthesis@mozilla.org.xpi addon/template/profile/extensions
 
 # The 'prosthesis' target was folded into the 'profile' target, so it is just

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean profile prosthesis b2g adb locales run package help
+.PHONY: build clean profile prosthesis b2g adb locales run package test help
 
 -include local.mk
 

--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,12 @@ help:
 	@echo 'Targets:'
 	@echo "  build: [default] build, download, install everything;\n"\
 	"         combines the profile, b2g, and adb make targets"
+	@echo '  clean: remove files created during the build process'
 	@echo '  profile: make the Gaia profile and its prosthesis addon'
 	@echo '  b2g: download and install B2G'
 	@echo '  adb: download and install ADB'
+	@echo '  locales: pull/update l10n repositories for specified locales'
 	@echo '  run: start Firefox with the addon installed into a new profile'
 	@echo '  package: package the addon into a XPI'
-	@echo '  clean: remove files created during the build process'
+	@echo '  test: run automated tests'
 	@echo '  help: show this message'

--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,11 @@ prosthesis: profile
 b2g:
 	python build/make-b2g.py $(B2G_TYPE_ARG) $(B2G_PLATFORM_ARG) $(B2G_ID_ARG) $(B2G_URL_ARG)
 
+# We used to store the binaries in the B2G_PLATFORM/ directory, whereas
+# now we store them in B2G_PLATFORM/adb/, which happens to be the same
+# as the names of the executables on Mac and Linux; so we need to remove
+# the executables from B2G_PLATFORM/ before creating B2G_PLATFORM/adb/.
 adb:
-	# We used to store the binaries in the B2G_PLATFORM/ directory, whereas
-	# now we store them in B2G_PLATFORM/adb/, which happens to be the same
-	# as the names of the executables on Mac and Linux; so we need to remove
-	# the executables from B2G_PLATFORM/ before creating B2G_PLATFORM/adb/.
 	mkdir -p addon/data/$(B2G_PLATFORM)
 	cd addon/data/$(B2G_PLATFORM) && rm -rf adb $(ADB_BINARIES)
 	mkdir addon/data/$(B2G_PLATFORM)/adb

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,9 @@ build: profile b2g adb
 clean:
 	rm -rf addon/data/$(B2G_PLATFORM)
 	rm -rf addon/template
-	rm gaia/build/custom-prefs.js
-	rm gaia/build/custom-settings.json
-	rm $(ADB_PACKAGE)
+	rm -f gaia/build/custom-prefs.js
+	rm -f gaia/build/custom-settings.json
+	rm -f $(ADB_PACKAGE)
 	make -C gaia clean
 
 profile:

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ clean:
 	rm -f gaia/build/custom-settings.json
 	rm -f $(ADB_PACKAGE)
 	make -C gaia clean
+	python build/make-b2g.py $(B2G_TYPE_ARG) $(B2G_PLATFORM_ARG) $(B2G_ID_ARG) $(B2G_URL_ARG) --clean
 
 profile:
 	cp build/override-prefs.js gaia/build/custom-prefs.js

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ifneq ($(strip $(LOCALES_FILE)),)
   endif
 endif
 
-build: profile prosthesis b2g adb
+build: profile b2g adb
 
 clean:
 	rm -rf addon/data/$(B2G_PLATFORM)
@@ -147,11 +147,13 @@ profile:
 	mv gaia/profile addon/template/
 	cp addon-sdk/app-extension/bootstrap.js addon/template/
 	cp addon-sdk/app-extension/install.rdf addon/template/
-
-prosthesis: profile
 	mkdir -p addon/template/profile/extensions
 	cd prosthesis && zip -r b2g-prosthesis\@mozilla.org.xpi content components defaults locale modules skin chrome.manifest install.rdf
 	mv prosthesis/b2g-prosthesis@mozilla.org.xpi addon/template/profile/extensions
+
+# The 'prosthesis' target was folded into the 'profile' target, so it is just
+# an alias to that target now.
+prosthesis: profile
 
 b2g:
 	python build/make-b2g.py $(B2G_TYPE_ARG) $(B2G_PLATFORM_ARG) $(B2G_ID_ARG) $(B2G_URL_ARG)
@@ -182,9 +184,8 @@ test:
 help:
 	@echo 'Targets:'
 	@echo "  build: [default] build, download, install everything;\n"\
-	"         combines the profile, prosthesis, b2g, and adb make targets"
-	@echo '  profile: make the Gaia profile'
-	@echo '  prosthesis: make the prosthesis addon that enhances B2G'
+	"         combines the profile, b2g, and adb make targets"
+	@echo '  profile: make the Gaia profile and its prosthesis addon'
 	@echo '  b2g: download and install B2G'
 	@echo '  adb: download and install ADB'
 	@echo '  run: start Firefox with the addon installed into a new profile'

--- a/build/make-b2g.py
+++ b/build/make-b2g.py
@@ -32,6 +32,10 @@ parser.add_option('--platform', '-p',
                   metavar='PLATFORM',
                   help='the platform of the build; '
                        'default: the current platform')
+parser.add_option("--clean",
+                  action="store_true",
+                  dest="clean",
+                  help='remove previously downloaded package')
 
 # Option group for nightly builds.
 group = OptionGroup(parser, "nightly builds",
@@ -120,19 +124,17 @@ elif options.type == 'specific':
 else:
   raise NotImplementedError('type %s not supported' % options.type)
 
-print "Initiating B2G download."
-build.download()
-
-
-# Install B2G Desktop to addon's data directory.
 installer = os.path.abspath(build.target)
 
-# Remove the existing installation, then install.
-platformdir = os.path.join(datadir, platform)
-shutil.rmtree(os.path.join(platformdir, installdirname), True)
-mozinstall.install(installer, platformdir)
+if options.clean:
+  if os.path.isfile(installer):
+    print "Removing B2G package."
+    os.remove(installer)
 
-
-# Clean up.
-
-#shutil.rmtree(tmpdir)
+else:
+  print "Initiating B2G download."
+  build.download()
+  # Remove the existing installation, then install.
+  platformdir = os.path.join(datadir, platform)
+  shutil.rmtree(os.path.join(platformdir, installdirname), True)
+  mozinstall.install(installer, platformdir)


### PR DESCRIPTION
The change that prompted this branch was the merger of the profile and prosthesis targets, since they depended on each other, and thus it was misleading to have both (and users who did `make profile` would get a broken profile that couldn't be used with the addon because the prosthesis addon wouldn't be installed in B2G).

But along the way I identified a bunch of other things to improve and have implemented them. The commit log should explain each change.
