### PR TITLE
Add limited set of sanity checks for usage of appcache in webapps.

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -23,6 +23,7 @@ const JsonLint = require("jsonlint/jsonlint");
 const ADB = require("adb");
 const Promise = require("sdk/core/promise");
 const Runtime = require("runtime");
+const Validator = require("./validator");
 
 // The b2gremote debugger module that installs apps to devices.
 const Debugger = require("debugger");
@@ -755,6 +756,15 @@ let simulator = module.exports = {
     // NOTE: add errors/warnings for WebAPIs not supported by the simulator
     simulator._validateWebAPIs(app.validation.errors, app.validation.warnings,
                                app.manifest);
+
+    // Appcache checks
+    if (["generated", "hosted"].indexOf(app.type) !== -1) {
+      // Only verify appcache for hosted apps
+      Validator.validateAppCache(app.validation.errors, app.validation.warnings,
+                                 app.manifest, app.origin);
+    } else if ("appcache_path" in app.manifest) {
+      app.validation.warnings.push("Packaged apps don't support appcache");
+    }
 
     if (["generated", "hosted"].indexOf(app.type) !== -1 &&
         ["certified", "privileged"].indexOf(app.manifest.type) !== -1) {

--- a/addon/lib/validator.js
+++ b/addon/lib/validator.js
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const { Ci, Cu, Cr } = require("chrome");
+
+const AppsUtils = Cu.import("resource://gre/modules/AppsUtils.jsm");
+const { Services } = Cu.import("resource://gre/modules/Services.jsm");
+const { defer } = require('sdk/core/promise');
+
+exports.validateAppCache = function(errors, warnings, rawManifest, origin) {
+  let deferred = defer();
+
+  // Use ManifestHelper to normalize and retrieve the absolute appcache URI
+  let manifest = new AppsUtils.ManifestHelper(rawManifest, origin);
+  if (!manifest.appcache_path) {
+    deferred.resolve();
+    return deferred.promise;
+  }
+  let path = manifest.fullAppcachePath();
+  let uri = Services.io.newURI(path, null, null);
+
+  // Appcache only accepts http/https uris
+  // http://hg.mozilla.org/mozilla-central/file/c80dc6ffe865/uriloader/prefetch/nsOfflineCacheUpdate.cpp#l1249
+  if (uri.scheme != "http" && uri.scheme != "https") {
+    errors.push("Appcache only accepts http/https URIs");
+    deferred.resolve();
+  } else {
+    // Appcache reject any redirect
+    // http://hg.mozilla.org/mozilla-central/file/044d554846ff/uriloader/prefetch/nsOfflineCacheUpdate.cpp#l292
+    let channel = Services.io.newChannel(uri.spec, null, null);
+    let listener = new ChannelListener(function (redirectedURI, status) {
+      if (redirectedURI) {
+        errors.push("Redirected appcache manifests are ignored. " + uri.spec +
+                    " has been redirected to " + redirectedURI);
+      }
+      // Appcache does various check for nsIHttpChannel.requestSucceeded,
+      // which is equivalent to checking if status code isn't 2XX
+      if (Math.floor(status / 100) != 2)
+        errors.push("Appcache URL (" + uri.spec + ") returns a " + status +
+                    " HTTP status code and will be ignored");
+      deferred.resolve();
+    });
+    channel.asyncOpen(listener, null);
+    channel.notificationCallbacks = listener;
+  }
+
+  return deferred.promise;
+}
+
+// nsIStreamListener+nsIChannelEventSink instance to check if a given nsIChannel
+// is being explicitly redirected. `onDone` function will be called
+// when the channel is loaded and receive two arguments:
+// * a string representing the URL to which the request was redirected,
+//   or null if the request wasn't redirected
+// * the http status code
+function ChannelListener(onDone) {
+  this.redirected = false;
+  this.onDone = onDone;
+}
+ChannelListener.prototype = {
+  onStartRequest: function(request, context) {},
+  onDataAvailable: function(request, context, stream, offset, count) {},
+  onStopRequest: function(request, context, status) {
+    request.QueryInterface(Ci.nsIHttpChannel);
+    this.onDone(this.redirected ? request.URI.spec : false,
+                request.responseStatus);
+  },
+
+  QueryInterface: function(iid) {
+    if (iid.equals(Ci.nsISupports) ||
+        iid.equals(Ci.nsIFactory) ||
+        iid.equals(Ci.nsIChannelEventSink) ||
+        iid.equals(Ci.nsIStreamListener))
+      return this;
+    throw Cr.NS_ERROR_NO_INTERFACE;
+  },
+  createInstance: function(outer, iid) {
+    if (outer)
+      throw Cr.NS_ERROR_NO_AGGREGATION;
+    return this.QueryInterface(iid);
+  },
+  lockFactory: function(lock) {
+    throw Cr.NS_ERROR_NOT_IMPLEMENTED;
+  },
+
+  asyncOnChannelRedirect: function(oldChan, newChan, flags, callback) {
+    // Ignore redirection due to internal implementation reasons
+    if (!(flags & Ci.nsIChannelEventSink.REDIRECT_INTERNAL)) {
+      this.redirected = true;
+    }
+    // Accept the redirect in order to ensure onStopRequest to be called
+    callback.onRedirectVerifyCallback(Cr.NS_OK);
+    return Cr.NS_OK;
+  },
+
+  getInterface: function eventsink_gi(iid) {
+    if (iid.equals(Ci.nsIChannelEventSink))
+      return this;
+    throw Cr.NS_ERROR_NO_INTERFACE;
+  }
+};

--- a/addon/test/test-validator.js
+++ b/addon/test/test-validator.js
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const validator = require("validator");
+const httpd = require("sdk/test/httpd");
+
+const port = 9999;
+const origin = "http://localhost:" + port;
+let server;
+
+// SDK tests are run in alphabetic order, so rely on that property to
+// run setup and teardown test steps
+exports["test A setup"] = function (assert) {
+  server = httpd.startServerAsync(port);
+  server.registerPathHandler("/appcache.manifest", function handle(request, response) {
+    response.write("");
+  });
+  assert.pass("Setup");
+}
+
+exports["test validate empty appcache"] = function(assert, done) {
+  let errors = [], warnings = [];
+  let manifest = {};
+  let promise = validator.validateAppCache(errors, warnings, manifest, "http://mozilla.org");
+  promise.then(function () {
+    assert.equal(errors.length, 0, "no error");
+    assert.equal(warnings.length, 0, "no warning");
+    done();
+  });
+}
+
+exports["test relative path"] = function(assert, done) {
+  let errors = [], warnings = [];
+  let manifest = {appcache_path: "appcache.manifest"};
+  let promise = validator.validateAppCache(errors, warnings, manifest, origin);
+  promise.then(function () {
+    assert.equal(errors.length, 0, "no error for relative path");
+    assert.equal(warnings.length, 0, "no warning for relative path");
+    done();
+  })
+}
+
+exports["test absolute path"] = function(assert, done) {
+  let errors = [], warnings = [];
+  let manifest = {appcache_path: "/appcache.manifest"};
+  let promise = validator.validateAppCache(errors, warnings, manifest, origin);
+  promise.then(function () {
+    assert.equal(errors.length, 0, "still no error for absolute path");
+    assert.equal(warnings.length, 0, "still no warning for absolute path");
+    done();
+  });
+}
+
+exports["test absolute URI"] = function(assert, done) {
+  let errors = [], warnings = [];
+  let manifest = {appcache_path: origin + "/appcache.manifest"};
+  let promise = validator.validateAppCache(errors, warnings, manifest, origin);
+  promise.then(function () {
+    assert.equal(errors.length, 0, "no error for absolute URI");
+    assert.equal(warnings.length, 0, "no warning for absolute URI");
+    done();
+  });
+}
+
+exports["test redirected"] = function(assert, done) {
+  server.registerPathHandler("/redirected.manifest", function handle(request, response) {
+    response.setStatusLine(request.httpVersion, 301, "Moved Permanently");
+    response.setHeader("Location", origin + "/appcache.manifest", false);
+  });
+  let errors = [], warnings = [];
+  let manifest = {appcache_path: "redirected.manifest"};
+  let promise = validator.validateAppCache(errors, warnings, manifest, origin);
+  promise.then(function () {
+    assert.equal(errors.length, 1, "redirected manifest are ignored");
+    assert.equal(
+      errors[0],
+      "Redirected appcache manifests are ignored. " +
+      "http://localhost:9999/redirected.manifest has been redirected to " +
+      "http://localhost:9999/appcache.manifest");
+    assert.equal(warnings.length, 0, "no warning for absolute URI");
+    done();
+  });
+}
+
+exports["test nonexistent"] = function(assert, done) {
+  server.registerPathHandler("/nonexistent.manifest", function handle(request, response) {
+    response.setStatusLine(request.httpVersion, 404, "Not Found");
+  });
+  let errors = [], warnings = [];
+  let manifest = {appcache_path: "nonexistent.manifest"};
+  let promise = validator.validateAppCache(errors, warnings, manifest, origin);
+  promise.then(function () {
+    assert.equal(errors.length, 1, "nonexistent manifest are warned");
+    assert.equal(
+      errors[0],
+      "Appcache URL (http://localhost:9999/nonexistent.manifest) returns a " +
+      "404 HTTP status code and will be ignored");
+    assert.equal(warnings.length, 0, "no warning for absolute URI");
+    done();
+  });
+}
+
+exports["test z teardown"] = function (assert, done) {
+  server.stop(done);
+  assert.pass("teardown");
+}
+
+require('sdk/test').run(exports);


### PR DESCRIPTION
I have the feeling that it would be better to improve installation and runtime code to expose error messages instead of doing nothing -or- dumping almost meaningless error code in b2g stdout.
Another middle step could be to start sharing sanity check methods between apps platform code and the simulator.
If we continue on that road one another farer step could be to start implementing checks in simulator in order to eventually upstream them in this apps platform code, that's what I'm trying to do in this pull request with a first module that focuses on checking appcache related failures.

If you like this approach, I'd like to continue and factor out of simulator.js all validation code, especially `_validateNameIcons`, `_validateWebAPIs`. And also try to move prosthesis validation code hosted in simulator actor (`onValidateManifest` and `_validateManifestPermissions`) to the firefox addon [if that's reasonnably possible].
