### PR TITLE
escape warning and error messages

### DIFF
--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -114,7 +114,7 @@
                                 Errors:
                                 <ul class='app-validation-errors'>
                                     {% for msg in errors %}
-                                        <li>{{ msg }}</li>
+                                        <li><pre>{{ msg | escape }}</pre></li>
                                     {% endfor %}
                                 </ul>
                             {% endif %}
@@ -122,7 +122,7 @@
                                 Warnings:
                                 <ul class='app-validation-warnings'>
                                     {% for msg in warnings %}
-                                        <li>{{ msg }}</li>
+                                        <li><pre>{{ msg | escape }}</pre></li>
                                     {% endfor %}
                                 </ul>
                             {% endif %}

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -689,7 +689,7 @@ let simulator = module.exports = {
         next(null, app.manifest);
       } catch(e) {
         if (typeof next === "function") {
-          next("<pre>"+e+"</pre>", null);
+          next(e, null);
         }
       }
       break;
@@ -705,7 +705,7 @@ let simulator = module.exports = {
             try {
               JsonLint.parse(response.text);
             } catch(e) {
-              error += "<pre>"+e+"</pre>";
+              error += e;
             }
           } else {
             app.manifest = response.json;


### PR DESCRIPTION
Fixes #522.

After looking into this, I think @kmaglione is right that there's a potential vector here, although I haven't identified a specific attack. But we want defense in depth, so we should mitigate against the potential risk, even without a known exploit.

Here's a fix that unconditionally escapes the warning and error messages in the Dashboard template. This has the side-effect of &lt;pre>formatting all messages, since the template can't distinguish between JSON linter messages (which are preformatted) and other messages (which aren't). I think that's ok, since the other messages are short one-liners that still look reasonable. But in the future we might consider annotating each message with a hint about how to format it.

@potch introduced this template post-3.0, so I'll need to craft a different fix for a 3.0 hotfix update if we decide to include this in one.
