### PR TITLE
escape warning and error messages

### DIFF
--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -242,7 +242,7 @@ var Simulator = {
                     entry.addClass("invalid-manifest");
                     var errorsEl = $("<ul class='app-validation-errors'>");
                     errors.forEach(function (msg) {
-                      errorsEl.append($("<li>").html(msg));
+                      errorsEl.append($("<li>").append($("<pre>").text(msg)));
                     });
                     listContainerEl.append($("<li>").
                                            text("Errors:").
@@ -253,7 +253,7 @@ var Simulator = {
                     entry.addClass("warning-manifest");
                     var warningsEl = $("<ul class='app-validation-warnings'>");
                     warnings.forEach(function (msg) {
-                      warningsEl.append($("<li>").html(msg));
+                      warningsEl.append($("<li>").append($("<pre>").text(msg)));
                     });
                     listContainerEl.append($("<li>").
                                            text("Warnings:").

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -695,7 +695,7 @@ let simulator = module.exports = {
         next(null, app.manifest);
       } catch(e) {
         if (typeof next === "function") {
-          next("<pre>"+e+"</pre>", null);
+          next(e, null);
         }
       }
       break;
@@ -711,7 +711,7 @@ let simulator = module.exports = {
             try {
               JsonLint.parse(response.text);
             } catch(e) {
-              error += "<pre>"+e+"</pre>";
+              error += e;
             }
           } else {
             app.manifest = response.json;


### PR DESCRIPTION
Here's the 3.0 branch equivalent of the fix for #522. If we decide to do a 3.0.1 hotfix update, which I'm leaning toward (primarily to pick up #527), we should take this too.

It is cherry picked from commit 38919575fe4a04472d16489f53e2698c6e01f977, which had conflicts in addon/data/content/index.html (namely: the master version modified the Nunjucks template in that HTML file, while the branch version has to modify the jQuery code in main.js).
