### PR TITLE
Fix opening Simulator while being a new private browsing window. Fixes #246.

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -10,6 +10,7 @@ const { Cc, Ci, Cr, Cu } = require("chrome");
 const Self = require("self");
 const URL = require("url");
 const Tabs = require("tabs");
+const Windows = require("sdk/windows").browserWindows;
 const UUID = require("sdk/util/uuid");
 const File = require("file");
 const Prefs = require("preferences-service");
@@ -990,7 +991,7 @@ let simulator = module.exports = {
       }
     }
 
-    Tabs.open({
+    Windows.activeWindow.tabs.open({
       url: url
     });
   },


### PR DESCRIPTION
I opened an SDK bug in order to eventually fix that weirdness: https://bugzilla.mozilla.org/show_bug.cgi?id=874554
