### PR TITLE
Move all manifest validation logic to /addon/lib/validator.js and unit test it.

### DIFF
--- a/addon/test/test-validator.js
+++ b/addon/test/test-validator.js
@@ -31,7 +31,7 @@ exports["test validate empty appcache"] = function(assert, done) {
   });
 }
 
-exports["test relative path"] = function(assert, done) {
+exports["test relative appcache path"] = function(assert, done) {
   let errors = [], warnings = [];
   let manifest = {appcache_path: "appcache.manifest"};
   let promise = validator.validateAppCache(errors, warnings, manifest, origin);
@@ -42,7 +42,7 @@ exports["test relative path"] = function(assert, done) {
   })
 }
 
-exports["test absolute path"] = function(assert, done) {
+exports["test absolute appcache path"] = function(assert, done) {
   let errors = [], warnings = [];
   let manifest = {appcache_path: "/appcache.manifest"};
   let promise = validator.validateAppCache(errors, warnings, manifest, origin);
@@ -53,7 +53,7 @@ exports["test absolute path"] = function(assert, done) {
   });
 }
 
-exports["test absolute URI"] = function(assert, done) {
+exports["test absolute apccache URI"] = function(assert, done) {
   let errors = [], warnings = [];
   let manifest = {appcache_path: origin + "/appcache.manifest"};
   let promise = validator.validateAppCache(errors, warnings, manifest, origin);
@@ -64,7 +64,7 @@ exports["test absolute URI"] = function(assert, done) {
   });
 }
 
-exports["test redirected"] = function(assert, done) {
+exports["test redirected appcache"] = function(assert, done) {
   server.registerPathHandler("/redirected.manifest", function handle(request, response) {
     response.setStatusLine(request.httpVersion, 301, "Moved Permanently");
     response.setHeader("Location", origin + "/appcache.manifest", false);
@@ -84,7 +84,7 @@ exports["test redirected"] = function(assert, done) {
   });
 }
 
-exports["test nonexistent"] = function(assert, done) {
+exports["test nonexistent appcache"] = function(assert, done) {
   server.registerPathHandler("/nonexistent.manifest", function handle(request, response) {
     response.setStatusLine(request.httpVersion, 404, "Not Found");
   });
@@ -100,6 +100,176 @@ exports["test nonexistent"] = function(assert, done) {
     assert.equal(warnings.length, 0, "no warning for absolute URI");
     done();
   });
+}
+
+exports["test empty manifest"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {}, app = {};
+  validator.validateNameIcons(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1, "missing name in manifest is an error");
+  assert.equal(errors[0], "Missing mandatory 'name' in Manifest.");
+  assert.equal(warnings.length, 1, "missing icons in manifest causes a warning");
+  assert.equal(warnings[0], "Missing 'icons' in Manifest.");
+}
+
+exports["test biggest icon selection"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    name: "foo",
+    icons: {"16": "16.png", "128": "128.png", "32": "32.png"}
+  };
+  let app = {};
+  validator.validateNameIcons(errors, warnings, manifest, app);
+  assert.equal(errors.length, 0);
+  assert.equal(warnings.length, 0);
+  assert.equal(app.name, "foo", "app.name has been set");
+  assert.equal(app.icon, "128.png", "selected the biggest icon");
+}
+
+exports["test marketplace icon size condition"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    name: "foo",
+    icons: {"16": "16.png"}
+  };
+  let app = {};
+  validator.validateNameIcons(errors, warnings, manifest, app);
+  assert.equal(errors.length, 0);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0], "app submission to the Marketplace needs at least an 128 icon");
+}
+
+exports["test privileged hosted"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    type: "privileged"
+  };
+  let app = {
+    type: "hosted"
+  };
+  validator.validateType(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Hosted App can't be type 'privileged'.");
+}
+
+exports["test unknown type"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    type: "privilegeddd"
+  };
+  let app = {};
+  validator.validateType(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Unknown app type: 'privilegeddd'.");
+}
+
+exports["test certified warning"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    type: "certified"
+  };
+  let app = {
+    type: "packaged"
+  };
+  validator.validateType(errors, warnings, manifest, app);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0], "'certified' apps are not fully supported on the Simulator.");
+}
+
+exports["test simulator unsupported permission"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {sms : {}}
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0], "WebAPI 'WebSMS' is not currently supported on the Simulator");
+}
+
+exports["test certified only permission - accepted"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {mobileconnection : {}},
+    type: "certified"
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 0);
+  assert.equal(warnings.length, 0);
+}
+
+exports["test certified only permission - denied"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {mobileconnection : {}}
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Denied permission 'mobileconnection' for app type 'web'.");
+}
+
+exports["test permission access"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {"device-storage:videos" : {access: "readonly"}},
+    type: "privileged"
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 0);
+  assert.equal(warnings.length, 0);
+}
+
+exports["test permission wrong access"] = function(assert) {
+  // Typo in access
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {"device-storage:videos" : {access: "readonlyyy"}},
+    type: "privileged"
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Invalid access 'readonlyyy' in permission 'device-storage:videos'.");
+}
+
+exports["test permission access on permission without access"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {"alarms" : {access: "readonly"}}
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Invalid access 'readonly' in permission 'alarms'.");
+}
+
+exports["test permission denied access"] = function(assert) {
+  // Use an access field that doesn't match the targeted permission accesses
+  let errors = [], warnings = [];
+  let manifest = {
+    permissions: {"device-storage:apps" : {access: "createonly"}},
+    type: "certified"
+  };
+  let app = {};
+  validator.validatePermissions(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "Invalid access 'createonly' in permission 'device-storage:apps'.");
+}
+
+exports["test checkManifest - non-numeric size"] = function(assert) {
+  let errors = [], warnings = [];
+  let manifest = {
+    name: "foo",
+    size: "non-numeric-size"
+  };
+  let app = {};
+  validator.validateManifest(errors, warnings, manifest, app);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0], "This app can't be installed on a production device " +
+                          "(AppsUtils.checkManifest return false).");
 }
 
 exports["test z teardown"] = function (assert, done) {


### PR DESCRIPTION
So I looked at differences between gecko18 and m-c on PermissionTables and AppsUtils and the result is that:
- there is no differences for AppsUtils
- only one commit, that should ideally be uplifted on PermissionTables - http://hg.mozilla.org/mozilla-central/rev/01f0d7b85857

Given that, it would be really easier and less error prone to move all validation logic to the addon. It may save us from races involved in this complex asynchronous code.

Also, it highlights that we are doing the same check twice.
The main fact that prevent sharing validation code is that the platform code is extremelly bad at reporting what is going wrong. It just returns false and sometimes tries to print something to the console.
Speaking about developer tools, we should aim to fix that at the source and improve error reporting when installing an App. By doing so, I think we should be able to reuse the validation logic being involved in the platform in order to execute some check before installing the app.
