### PR TITLE
Request changes from jetpack 1.14 not master 

### DIFF
--- a/addon/lib/request.js
+++ b/addon/lib/request.js
@@ -16,7 +16,6 @@ const { EventTarget } = require("sdk/event/target");
 const { Class } = require("sdk/core/heritage");
 const { XMLHttpRequest } = require("sdk/net/xhr");
 const apiUtils = require("sdk/deprecated/api-utils");
-const { isValidURI } = require("url.js");
 
 const response = ns();
 const request = ns();
@@ -25,9 +24,8 @@ const request = ns();
 // reuse it.
 const { validateOptions, validateSingleOption } = new OptionsValidator({
   url: {
-    // Also converts a URL instance to string, bug 857902
-    map: function (url) url.toString(),
-    ok: isValidURI
+    //XXXzpao should probably verify that url is a valid url as well
+    is:  ["string"]
   },
   headers: {
     map: function (v) v || {},
@@ -74,8 +72,6 @@ function runRequest(mode, target) {
 
   // open the request
   xhr.open(mode, url);
-
-  xhr.forceAllowThirdPartyCookie();
 
   // request header must be set after open, but before send
   xhr.setRequestHeader("Content-Type", contentType);


### PR DESCRIPTION
Fixes #553

Sorry, I accidentally took as a base for my changes `request.js` from jetpack's master branch, not from 1.14. I reverted all the diffs not related to my patch for HEAD requests.
