### PR TITLE
FIX: clear appCache entries on run/update app requests using Services.evictEntries

### DIFF
--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -102,10 +102,16 @@ SimulatorActor.prototype = {
     let appId = aRequest.appId;
 
     if (!DOMApplicationRegistry.webapps[appId]) {
-      return { success: false, error: 'app-not-installed', message: 'App not installed.'}
+      return { success: false, error: 'app-not-installed', message: 'App not installed.'};
     }
 
     let appOrigin = DOMApplicationRegistry.webapps[appId].origin;
+    let localId = DOMApplicationRegistry.webapps[appId].localId;
+
+    if (localId) {
+      debug("RUNAPP: clear all associated appCache entries");
+      DOMApplicationRegistry._clearPrivateData(localId, false);
+    }
 
     let debug = this.debug.bind(this);
 
@@ -159,8 +165,6 @@ SimulatorActor.prototype = {
         }
       },
       tryAppReloadByOrigin: function(origin, cb) {
-        debug("RUNAPP: clear all appCache entries");
-        Services.cache.evictEntries(Ci.nsICache.STORE_OFFLINE);
         debug("RUNAPP: tryAppReloadByOrigin - " + origin);
         try {
           if (WindowManager.getRunningApps()[origin] &&

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -159,6 +159,8 @@ SimulatorActor.prototype = {
         }
       },
       tryAppReloadByOrigin: function(origin, cb) {
+        debug("RUNAPP: clear all appCache entries");
+        Services.cache.evictEntries(Ci.nsICache.STORE_OFFLINE);
         debug("RUNAPP: tryAppReloadByOrigin - " + origin);
         try {
           if (WindowManager.getRunningApps()[origin] &&

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -106,15 +106,12 @@ SimulatorActor.prototype = {
     }
 
     let appOrigin = DOMApplicationRegistry.webapps[appId].origin;
-    let localId = DOMApplicationRegistry.webapps[appId].localId;
 
     let debug = this.debug.bind(this);
 
     let runnable = {
       run: function() {
         try {
-          runnable.cleanAppCache();
-
           runnable.waitHomescreenReady(function () {
             runnable.tryAppReloadByOrigin(appOrigin, function () {
               runnable.findAppByOrigin(appOrigin, function (e, app) {
@@ -135,26 +132,6 @@ SimulatorActor.prototype = {
           });
         } catch(e) {
           debug(["EXCEPTION:", e, e.fileName, e.lineNumber].join(' '));
-        }
-      },
-      cleanAppCache: function() {
-        if (!localId) {
-          return;
-        }
-
-        debug("RUNAPP: clear all associated appCache entries");
-        try {
-          let cacheService = Cc["@mozilla.org/network/application-cache-service;1"].
-          getService(Ci.nsIApplicationCacheService);
-          cacheService.discardByAppId(localId, false);
-        } catch(e) {
-          // NOTE: currently cacheService.discardByAppId always raise an expection
-          // even if it's working correctly (and cache entries are refreshed on app
-          // window reload)
-          // EXCEPTION on localId NNNN: [Exception... "Component returned failure code: 0x8000ffff \
-          // (NS_ERROR_UNEXPECTED) [nsIApplicationCacheService.discardByAppId]" \
-          // nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)" ...
-          // debug("EXCEPTION on localId " + localId + ": " + e);
         }
       },
       waitHomescreenReady: function(cb) {

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -112,23 +112,22 @@ function simulatorAppUpdate(clearAppCache) {
 }
 
 function simulatorClearAppCache(appId) {
-    let localId = DOMApplicationRegistry.webapps[appId].localId;
+  let localId = DOMApplicationRegistry.webapps[appId].localId;
 
-    if (!localId) {
-        return;
-    }
+  if (!localId) {
+    return;
+  }
 
-    try {
-        let cacheService = Cc["@mozilla.org/network/application-cache-service;1"].
-            getService(Ci.nsIApplicationCacheService);
-        cacheService.discardByAppId(localId, false);
-    } catch(e) {
-        // NOTE: currently cacheService.discardByAppId always raise an expection
-        // even if it's working correctly (and cache entries are refreshed on app
-        // window reload)
-        // EXCEPTION on localId NNNN: [Exception... "Component returned failure code: 0x8000ffff \
-        // (NS_ERROR_UNEXPECTED) [nsIApplicationCacheService.discardByAppId]" \
-        // nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)" ...
-        // debug("EXCEPTION on localId " + localId + ": " + e);
-    }
+  try {
+    Cc["@mozilla.org/network/application-cache-service;1"].
+      getService(Ci.nsIApplicationCacheService).discardByAppId(localId, false);
+  } catch(e) {
+    // NOTE: currently cacheService.discardByAppId always raise an expection
+    // even if it's working correctly (and cache entries are refreshed on app
+    // window reload)
+    // EXCEPTION on localId NNNN: [Exception... "Component returned failure code: 0x8000ffff \
+    // (NS_ERROR_UNEXPECTED) [nsIApplicationCacheService.discardByAppId]" \
+    // nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)" ...
+    // debug("EXCEPTION on localId " + localId + ": " + e);
+  }
 }

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -95,8 +95,8 @@ function simulatorAppUpdate() {
   let wm = shell.contentBrowser.contentWindow.wrappedJSObject.
            WindowManager;
 
+  debug("request app reinstall");
   let origin = wm.getCurrentDisplayedApp().origin;
-
   Services.obs.notifyObservers({
     wrappedJSObject: {
       origin: origin,

--- a/prosthesis/content/shell.xul
+++ b/prosthesis/content/shell.xul
@@ -64,11 +64,6 @@
                   key="refreshAppKey"
                   accesskey="&refreshAppItem.accesskey;"
                   command="refreshAppCmd"/>
-        <menuitem id="refreshAppItem"
-                  label="&refreshAppAndClearAppCacheItem.label;"
-                  key="refreshAppAndClearAppCacheKey"
-                  accesskey="&refreshAppAndClearAppCacheItem.accesskey;"
-                  command="refreshAppAndClearAppCacheCmd"/>
       </menupopup>
     </menu>
   </menubar>

--- a/prosthesis/content/shell.xul
+++ b/prosthesis/content/shell.xul
@@ -44,17 +44,17 @@
   <commandset id="mainCommandSet">
     <command id="quitSimulatorCmd" oncommand="goQuitApplication()"/>
     <command id="refreshAppCmd" oncommand="simulatorAppUpdate()"/>
-    <command id="refreshAppAndClearAppCacheCmd" oncommand="simulatorAppUpdate(true)"/>
+    <command id="refreshClearCacheCmd" oncommand="simulatorAppUpdate(true)"/>
   </commandset>
   <keyset id="mainKeyset">
     <key id="refreshAppKey"
          modifiers="accel"
          key="&refreshAppKey.key;"
          command="refreshAppCmd"/>
-    <key id="refreshAppAndClearAppCacheKey"
+    <key id="refreshClearCacheKey"
          modifiers="shift accel"
          key="&refreshAppKey.key;"
-         command="refreshAppAndClearAppCacheCmd"/>
+         command="refreshClearCacheCmd"/>
   </keyset>
   <menubar id="mainMenubar">
     <menu id="appMenu" label="&appMenu.label;" accesskey="&appMenu.accesskey;">

--- a/prosthesis/content/shell.xul
+++ b/prosthesis/content/shell.xul
@@ -44,12 +44,17 @@
   <commandset id="mainCommandSet">
     <command id="quitSimulatorCmd" oncommand="goQuitApplication()"/>
     <command id="refreshAppCmd" oncommand="simulatorAppUpdate()"/>
+    <command id="refreshAppAndClearAppCacheCmd" oncommand="simulatorAppUpdate(true)"/>
   </commandset>
   <keyset id="mainKeyset">
     <key id="refreshAppKey"
          modifiers="accel"
          key="&refreshAppKey.key;"
          command="refreshAppCmd"/>
+    <key id="refreshAppAndClearAppCacheKey"
+         modifiers="shift accel"
+         key="&refreshAppKey.key;"
+         command="refreshAppAndClearAppCacheCmd"/>
   </keyset>
   <menubar id="mainMenubar">
     <menu id="appMenu" label="&appMenu.label;" accesskey="&appMenu.accesskey;">
@@ -59,6 +64,11 @@
                   key="refreshAppKey"
                   accesskey="&refreshAppItem.accesskey;"
                   command="refreshAppCmd"/>
+        <menuitem id="refreshAppItem"
+                  label="&refreshAppAndClearAppCacheItem.label;"
+                  key="refreshAppAndClearAppCacheKey"
+                  accesskey="&refreshAppAndClearAppCacheItem.accesskey;"
+                  command="refreshAppAndClearAppCacheCmd"/>
       </menupopup>
     </menu>
   </menubar>

--- a/prosthesis/locale/en-US/shell.dtd
+++ b/prosthesis/locale/en-US/shell.dtd
@@ -25,7 +25,3 @@
 <!ENTITY refreshAppItem.label                      "Refresh">
 <!ENTITY refreshAppItem.accesskey                  "R">
 <!ENTITY refreshAppKey.key                         "R">
-
-<!ENTITY refreshAppAndClearAppCacheItem.label                      "Refresh and Clear AppCache">
-<!ENTITY refreshAppAndClearAppCacheItem.accesskey                  "C">
-<!ENTITY refreshAppAndClearAppCacheItem.key                         "R">

--- a/prosthesis/locale/en-US/shell.dtd
+++ b/prosthesis/locale/en-US/shell.dtd
@@ -25,3 +25,7 @@
 <!ENTITY refreshAppItem.label                      "Refresh">
 <!ENTITY refreshAppItem.accesskey                  "R">
 <!ENTITY refreshAppKey.key                         "R">
+
+<!ENTITY refreshAppAndClearAppCacheItem.label                      "Refresh and Clear AppCache">
+<!ENTITY refreshAppAndClearAppCacheItem.accesskey                  "C">
+<!ENTITY refreshAppAndClearAppCacheItem.key                         "R">


### PR DESCRIPTION
clear appCache entries on run app requests on run / update user requests (should fix #66)
