### PR TITLE
Fix regression introduced by PR #510. Fixes #555.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,10 @@ clean:
 profile:
 	cp build/override-prefs.js gaia/build/custom-prefs.js
 	cp build/override-settings.json gaia/build/custom-settings.json
-	NOFTU=1 BROWSER=1 GAIA_APP_SRCDIRS=apps make -C gaia
+	NOFTU=1 GAIA_APP_SRCDIRS=apps make -C gaia
 	python build/override-webapps.py
-	cd gaia/profile/extensions/desktop-helper/ && zip -r ../desktop-helper\@gaiamobile.org.xpi *
-	cd gaia/profile/extensions/activities/ && zip -r ../activities\@gaiamobile.org.xpi *
+	cd gaia/tools/extensions/desktop-helper/ && zip -r ../desktop-helper\@gaiamobile.org.xpi *
+	cd gaia/tools/extensions/activities/ && zip -r ../activities\@gaiamobile.org.xpi *
 	rm -rf gaia/profile/startupCache
 	rm -rf addon/template
 	mkdir -p addon/template


### PR DESCRIPTION
I was confused in these multiple gaia modes...
What we actually want is just the desktop helper addon, not the browser mode (i.e. not the BROWSER=1)

That will fix issue reported in PR #555.
