### PR TITLE
Fixed a typo (aDir => appDir)

### DIFF
--- a/prosthesis/content/dbg-webapps-actors.js
+++ b/prosthesis/content/dbg-webapps-actors.js
@@ -275,7 +275,7 @@ WebappsActor.prototype = {
 
       if (missing) {
         try {
-          aDir.remove(true);
+          appDir.remove(true);
         } catch(e) {}
         return { error: "badParameterType",
                  message: "hosted app file is missing" }


### PR DESCRIPTION
I think this must have been an artifact of an older version of the code where the `appDir` variable was called `aDir`
