### PR TITLE
Bypass devtools connect page by automatically connecting to shell.xul.

### DIFF
--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -76,6 +76,7 @@ const RemoteSimulatorClient = Class({
       let client = data.client;
       this.once("kill", function () client.close());
       client.request({to: "root", type: "listTabs"}, (function (reply) {
+        this._rootActor = reply;
         emit(this, "clientReady", {
           client: client,
           globals: reply,

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -924,29 +924,48 @@ let simulator = module.exports = {
   },
 
   openConnectDevtools: function() {
-    let port = this.remoteSimulator.remoteDebuggerPort;
-    let originalPort = Services.prefs.getIntPref("devtools.debugger.remote-port");
-    Tabs.open({
-      url: "chrome://browser/content/devtools/connect.xhtml",
-      onReady: function(tab) {
-        // Inject the allocated remote debugger port into the opened tab.
-        // We know it's a Number, so we don't actually need to parseInt it,
-        // but doing so reassures AMO reviewers that we aren't exposing
-        // a security issue.
-        tab.attach({
-          contentScript: "window.addEventListener(" +
-                         "  'load', " +
-                         "  function() " +
-                         "    document.getElementById('port').value = " +
-                         "      '" + parseInt(port, 10) + "', " +
-                         "  true" +
-                         ");"
-        }).on('detach', function restoreOriginalRemotePort() {
-          // restore previous value (autosaved on submit by connect.xhtml)
-          Services.prefs.setIntPref("devtools.debugger.remote-port", originalPort);
+    // Open a remote toolbox to shell.xul
+    let options = {
+      form: this.remoteSimulator._rootActor,
+      client: this.remoteSimulator._remote.client,
+      chrome: true
+    };
+    let {gDevTools} = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
+
+    // Devtools API changed at each 3 last FF version :'(
+    // Either on how to load modules, or how to use the API.
+    try {
+      let devtools;
+      try {
+        // FF24
+        devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
+      } catch(e) {
+        // FF23
+        devtools = Cu.import("resource:///modules/devtools/gDevTools.jsm", {}).devtools;
+      }
+      let promise = devtools.TargetFactory.forRemoteTab(options).then((target) => {
+        gDevTools.showToolbox(target, "webconsole", devtools.Toolbox.HostType.WINDOW);
+      });
+      // Ensure not killing remote connection when user close the toolbox
+      // Depends on bug 875104
+      promise.then(function (toolbox) {
+        toolbox.keepTargetAlive = true;
+      });
+    } catch(e) {
+      let TargetFactory = Cu.import("resource:///modules/devtools/Target.jsm", {}).TargetFactory;
+      let Toolbox = Cu.import("resource:///modules/devtools/Toolbox.jsm", {}).Toolbox;
+      if (TargetFactory.forRemote) {
+        // FF21
+        let target = TargetFactory.forTab(options.form, options.client, options.chrome);
+        gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.WINDOW);
+      } else {
+        // FF22
+        let target = TargetFactory.forTab(options);
+        target.makeRemote(options).then(function() {
+          gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.WINDOW);
         });
       }
-    });
+    }
   },
 
   kill: function(onKilled) {


### PR DESCRIPTION
Here is a patch to bypass the connect page.
It uses the existing remote connection to open a toolbox connected to toplevel shell.xul document. As far as I can tell that's the only target that is confirmed to work.

This patch isn't perfect as it kills the possibility to select another context other than shell.xul, but given that we can't select anything else, it would still be an incremental improvement.

The only issue is that it depends on a feature introduced in platform bug https://bugzilla.mozilla.org/show_bug.cgi?id=875104
Without this, the remote connection will be automatically closed when the user closes the toolbox. We can workaround this by using a new remote connection just for the toolbox, but I'd prefer keeping only one shared connection to avoid introducing bugs related to connection issues.
To ease that, I can easily factor out the toolbox "keepTargetAlive" feature, in order to land this feature and eventually uplift it.
In anycase, this feature would only exists in FF23/24.

Otherwise, there is various things to do after that:
- Open the toolbox in the same window, as a regular devtool toolbox
- Fix webapps actor to list apps actors and be able to target a given app context
- Add UI in the dashboard to connect to a precise app
