### PR TITLE
Refresh hosted apps installed outside of dashboard. Fixes #443

### DIFF
--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -335,6 +335,14 @@ const RemoteSimulatorClient = Class({
                                 onResponse);
   },
 
+  appNotFound: function(appId, onResponse) {
+    this._remote.client.request({ to: this._remote.simulator,
+                                  type: "appNotFound",
+                                  appId: appId
+                                },
+                                onResponse);
+  },
+
   // send a ping request to the remote simulator actor
   ping: function(onResponse) {
     let remote = this._remote;

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -1088,7 +1088,6 @@ let simulator = module.exports = {
         });
 
         if (!foundAppKey) {
-          console.log("Sending appNotFound: " + appId);
           simulator.remoteSimulator.appNotFound(appId);
         }
 

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -1088,7 +1088,8 @@ let simulator = module.exports = {
         });
 
         if (!foundAppKey) {
-          simulator.remoteSimulator.showNotification("App not updated (not found)");
+          console.log("Sending appNotFound: " + appId);
+          simulator.remoteSimulator.appNotFound(appId);
         }
 
         simulator.updateApp(foundAppKey, function next(error, app) {

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -4,10 +4,6 @@
 
 "use strict";
 
-let Cu = Components.utils;
-let Cc = Components.classes;
-let Ci = Components.interfaces;
-
 Cu.import("resource://gre/modules/Services.jsm");
 let { AppsUtils } = Cu.import("resource://gre/modules/AppsUtils.jsm");
 
@@ -288,7 +284,7 @@ SimulatorActor.prototype = {
       let contentType = req.getResponseHeader("content-type");
 
       if (AppsUtils.checkManifestContentType(installOrigin, origin, contentType) &&
-          manifestURL.indexOf('http://') === 0) {
+          manifestURL.indexOf('app:') !== 0) {
         onGoodContentType();
       } else {
         onBadContentType(contentType);
@@ -340,7 +336,7 @@ SimulatorActor.prototype = {
         uninstallReq.onsuccess = function onsuccess() {
           // Purge app cache
           try {
-            // This seems to legitamtely fail
+            // This seems to legitimately fail
             // (not actually flush the cache) if an app is:
             //    1. Installed from the dashboard
             //    2. Removed from the dashboard

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -359,7 +359,7 @@ SimulatorActor.prototype = {
           };
           installReq.onsuccess = function onsuccess() {
             actor.debug("Refresh successful");
-            let appId = DOMApplicationRegistry.appId(this.result.origin);
+            let appId = DOMApplicationRegistry._appId(this.result.origin);
             actor._runApp.call(actor, appId);
           };
         };

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -297,6 +297,8 @@ SimulatorActor.prototype = {
     let DOMApplicationRegistry = window.DOMApplicationRegistry;
     let app = DOMApplicationRegistry.webapps[appId];
 
+    this.debug("AppNotFound: " + appId);
+
     if (!app) {
       this._displayNotification("App not updated (not found)");
       return {};


### PR DESCRIPTION
Refreshing now works with hosted apps installed outside of the dashboard.
Try it on any app that calls `mozApps.install` or a marketplace app post-installation.

For now, it won't work until the simulator actors are initialized (see #571), so before refreshing any app, you must first run something from the dashboard.
