### PR TITLE
Disable addons update.

### DIFF
--- a/build/override-prefs.js
+++ b/build/override-prefs.js
@@ -1,0 +1,1 @@
+user-pref("extensions.update.enabled", false);


### PR DESCRIPTION
I've noticed that sometimes we see the addon update popup when launching b2g.
And then, most of the time, the profile seems to be corrupted and won't run anymore.
I'm wondering if it is the origin of the issue I mentioned here:
https://github.com/mozilla/r2d2b2g/issues/247#issuecomment-18541800
Where we see the following exception in jsconsole `nsIDOMEventListener::handleEvent]" nsresult: "0x80004001 (NS_ERROR_NOT_IMPLEMENTED)` and gaia won't ever start again. (stay on mozilla logo)

I think that this pref will disable this.
