### PR TITLE
Fix touch events on <select>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ profile:
 	cp build/override-prefs.js gaia/build/custom-prefs.js
 	cp build/override-settings.json gaia/build/custom-settings.json
 	NOFTU=1 GAIA_APP_SRCDIRS=apps make -C gaia
+	BROWSER=1 NOFTU=1 GAIA_APP_SRCDIRS=apps make -C gaia preferences
 	python build/override-webapps.py
 	cd gaia/tools/extensions/desktop-helper/ && zip -r ../../../profile/extensions/desktop-helper\@gaiamobile.org.xpi *
 	cd gaia/tools/extensions/activities/ && zip -r ../../../profile/extensions/activities\@gaiamobile.org.xpi *


### PR DESCRIPTION
I tried hard to make gaia build system configurable enough for the simulator, but it looks like it is still not enough.

So. I removed `BROWSER=1` when running gaia's make, as we really don't want this line to operate: https://github.com/mozilla-b2g/gaia/blob/master/build/webapp-manifests.js#L94-L96
(That's a very hacky way to make permissions work on Firefox)
It introduced issues with system app in the simulator, so I removed BROWSER=1 in this changeset: https://github.com/mozilla/r2d2b2g/commit/4e8e82447ead7778fcaefad7ef767e1664bdf121

But... we really want following prefs to be set:
https://github.com/mozilla-b2g/gaia/blob/master/build/preferences.js#L49-L76
Here, for touch events, we are missing the `dom.w3c_touch_events.enabled=1` pref.

I don't really know yet how to fix that in gaia, but we can easily fix that on simulator side for v4.
