### PR TITLE
Add UI for changing receipt types

### DIFF
--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -82,6 +82,12 @@
         <script type="text/template" id="app-template">
             <li class="app {{ 'removed' if removed }}" data-id="{{ id | escape }}">
                 <div class="options">
+                    <label>Receipt Type</label>
+                    <select class="receipt-type">
+                        {% for type in receiptTypes %}
+                            <option value="{{ type }}" {{ 'selected' if receiptType == type else '' }}>{{ type }}</option>
+                        {% endfor %}
+                    </select>
                     {% if removed %}
                         <button class="action" data-action="undo">Undo</button>
                     {% else %}

--- a/addon/data/content/js/applist.js
+++ b/addon/data/content/js/applist.js
@@ -56,7 +56,7 @@ var AppList = (function() {
             app.prettyLastUpdate = timedelta(app.lastUpdate);
         }
         app.prettyType = Simulator.APP_TYPES[app.type];
-        
+
         // use a default icon
         var iconPath = "default.png";
 
@@ -74,11 +74,23 @@ var AppList = (function() {
         }
 
         app.iconPath = iconPath;
+        app.receiptTypes = ['none', 'ok', 'expired', 'invalid', 'refunded'];
+
         var appEl = $(appTemplate.render(app).trim());
 
         // FIXME: Make an actual list, add a template engine
         listEl.append(appEl);
     }
+
+    listEl.on('change', '.receipt-type', function(e) {
+        var itemEl = $(this).parents('[data-id]');
+
+        if (!itemEl) return;
+
+        var id = itemEl.data('id');
+
+        window.postMessage({name: "updateReceiptType", id: id, receiptType: this.value}, "*");
+    });
 
     listEl.on('click', '.action', function(e) {
         var action = $(this).data('action');

--- a/addon/data/content/js/applist.js
+++ b/addon/data/content/js/applist.js
@@ -74,7 +74,7 @@ var AppList = (function() {
         }
 
         app.iconPath = iconPath;
-        app.receiptTypes = ['none', 'ok', 'expired', 'invalid', 'refunded'];
+        app.receiptTypes = ['none', 'ok', 'invalid', 'refunded'];
 
         var appEl = $(appTemplate.render(app).trim());
 

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -59,7 +59,7 @@ var Simulator = {
       window.postMessage({
         name: "addAppByTab",
         url: input.val().trim(),
-        receiptType: Simulator.getReceiptType(),
+        receiptType: Simulator.getReceiptType()
       }, "*");
       $("#form-add-app").get(0).reset();
     });

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -633,7 +633,7 @@ let simulator = module.exports = {
                   simulator.error("Error retrieving receipt. Please try adding the app again.");
                   console.error(err || "No receipt");
                 } else {
-                  simulator.addManifestUrl(tabUrl, receipt);
+                  simulator.addManifestUrl(tabUrl, receipt, receiptType);
                 }
               });
             } else {
@@ -683,7 +683,7 @@ let simulator = module.exports = {
     }
   },
 
-  addManifestUrl: function(manifestUrl, receipt) {
+  addManifestUrl: function(manifestUrl, receipt, receiptType) {
     console.log("Simulator.addManifestUrl " + manifestUrl);
 
     Request({
@@ -717,6 +717,7 @@ let simulator = module.exports = {
           manifestUrl: manifestUrl,
           webapp: response.json,
           receipt: receipt,
+          receiptType: receiptType,
         });
       }
     }).get();
@@ -755,7 +756,7 @@ let simulator = module.exports = {
     }).head();
   },
 
-  addManifest: function({ manifestUrl, webapp, installOrigin, generated, receipt }) {
+  addManifest: function({ manifestUrl, webapp, installOrigin, generated, receipt, receiptType }) {
     console.log("Simulator.addManifest " + manifestUrl);
     manifestUrl = URL.URL(manifestUrl.toString());
     let origin = manifestUrl.toString().substring(0, manifestUrl.toString().lastIndexOf(manifestUrl.path));
@@ -784,6 +785,7 @@ let simulator = module.exports = {
       host: manifestUrl.host,
       installOrigin: installOrigin,
       receipt: receipt,
+      receiptType: receiptType,
     }
     console.log("Registered App " + JSON.stringify(apps[id], null, 2));
 
@@ -1051,7 +1053,7 @@ let simulator = module.exports = {
     let next = null;
     // if needsUpdateAll try to reinstall all active registered app
     if (SStorage.storage.needsUpdateAll) {
-      next = (typeof cb === "function") ? 
+      next = (typeof cb === "function") ?
         (function(e) e ? cb(e) : simulator.updateAll(cb)) :
         (function(e) e ? null  : simulator.updateAll());
     } else {


### PR DESCRIPTION
Puts a receipt type `<select>` on each app listing. Changing the type triggers the appropriate app update.

fixes #494.
