### PR TITLE
Clean up how the device is shown when connected to the simulator

### DIFF
--- a/addon/data/content/css/main.css
+++ b/addon/data/content/css/main.css
@@ -509,13 +509,27 @@ section header {
 
 /* Device-related UI */
 .device-dependent {
-    transition: .5s opacity;
+    transition: .5s opacity, .5s height;
     opacity: 0;
     pointer-events: none;
 }
 .device-connected .device-dependent {
     opacity: 1;
     pointer-events: all;
+}
+
+#sidebar .device-dependent {
+    text-align: center;
+    height: 0;
+    margin: 0;
+}
+
+#sidebar .device-dependent img {
+    vertical-align: middle;
+}
+
+.device-connected #sidebar .device-dependent {
+    height: 50px;
 }
 
 .appIcon {

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -42,10 +42,10 @@
                         </label>
                     </fieldset>
                 </div>
-                <a id="help" class="item" href="https://developer.mozilla.org/en-US/docs/Tools/Firefox_OS_Simulator" target="_blank">Help</a>
                 <h5 id="device-status" class="device-dependent">
                     <img src="device.png" alt="Device"> Device connected.
                 </h5>
+                <a id="help" class="item" href="https://developer.mozilla.org/en-US/docs/Tools/Firefox_OS_Simulator" target="_blank">Help</a>
             </header>
 
             <section id="dashboard">


### PR DESCRIPTION
Currently, when you connect a device to the simulator, the icon on the sidebar is misplaced. This pull request intent fix this.
