### PR TITLE
Introduce devtool toolbox per app.

### DIFF
--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -103,6 +103,9 @@
                         <button class="action" data-action="remove">Remove</button>
                         <button class="action" data-action="update">Update</button>
                         <button class="action" data-action="run">Run</button>
+                        {% if opened %}
+                          <button class="action" data-action="connect">Connect</button>
+                        {% endif %}
                     {% endif %}
                 </div>
                 <h4>

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -82,9 +82,7 @@
                     {% else %}
                         <button class="action device-dependent" data-action="push">Push</button>
                         <button class="action" data-action="update">Update</button>
-                        {% if opened %}
-                          <button class="action" data-action="connect">Connect</button>
-                        {% endif %}
+                        <button class="action" data-action="connect">Connect</button>
                         <a href="javascript:;" title="Remove" class="action remove" data-action="remove">Remove</a>
                         <div class="receipt">
                             <label>Receipt:</label>

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -33,8 +33,6 @@
                               Remote Debugger Port:
                               <span id="commands-preference-remote-debugger-port"></span>
                             </div>
-                            <button id="open-connect-devtools" title="Connect Developer Tools&hellip;"
-                                    onclick="Simulator.openConnectDevtools()">Connect&hellip;</button>
                         </label>
                         <label class="commands-options" style="display: none">
                           Run:

--- a/addon/data/content/js/applist.js
+++ b/addon/data/content/js/applist.js
@@ -124,6 +124,9 @@ var AppList = (function() {
             case 'validation':
                 itemEl.find('.app-validation-list').toggle();
                 break;
+            case 'connect':
+                window.postMessage({name: "connectToApp", id: id}, "*");
+                break;
         }
 
     });

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -83,7 +83,7 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
       filter(function (appId) !Simulator.apps[appId].deleted);
 
     if (activeAppIds.length > 0) {
-      if (Services.vc.compare(lastVersion, "3.0pre3") < 0) {
+      if (Services.vc.compare(lastVersion, "4.0pre5dev") < 0) {
         ensureXkeysValid();
       }
       if (Services.vc.compare(lastVersion, "3.0pre5") < 0) {

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -83,7 +83,7 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
       filter(function (appId) !Simulator.apps[appId].deleted);
 
     if (activeAppIds.length > 0) {
-      if (Services.vc.compare(lastVersion, "4.0pre5dev") < 0) {
+      if (Services.vc.compare(lastVersion, "4.0pre7dev") < 0) {
         ensureXkeysValid();
       }
       if (Services.vc.compare(lastVersion, "3.0pre5") < 0) {

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -32,8 +32,8 @@ const Geolocation = Cc["@mozilla.org/geolocation;1"].getService(Ci.nsISupports);
 dbgClient.UnsolicitedNotifications.geolocationStart = "geolocationStart";
 dbgClient.UnsolicitedNotifications.geolocationStop = "geolocationStop";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
-dbgClient.UnsolicitedNotifications.webappsOpen = "webappsOpen";
-dbgClient.UnsolicitedNotifications.webappsClose = "webappsClose";
+dbgClient.UnsolicitedNotifications.appOpen = "appOpen";
+dbgClient.UnsolicitedNotifications.appClose = "appClose";
 
 // Log subprocess error and debug messages to the console.  This logs messages
 // for all consumers of the API.  We trim the messages because they sometimes
@@ -262,8 +262,8 @@ const RemoteSimulatorClient = Class({
 
     client.addListener("geolocationStart", this.onGeolocationStart.bind(this));
     client.addListener("geolocationStop", this.onGeolocationStop.bind(this));
-    client.addListener("webappsOpen", this.onWebappsOpen.bind(this));
-    client.addListener("webappsClose", this.onWebappsClose.bind(this));
+    client.addListener("appOpen", this.onAppOpen.bind(this));
+    client.addListener("appClose", this.onAppClose.bind(this));
 
     this._registerAppUpdateRequest(client);
 
@@ -317,14 +317,14 @@ const RemoteSimulatorClient = Class({
     }
   },
 
-  onWebappsOpen: function onWebappsOpen(type, packet) {
-    emit(this, "webappsOpen", {
+  onAppOpen: function onAppOpen(type, packet) {
+    emit(this, "appOpen", {
       manifestURL: packet.manifestURL
     });
   },
 
-  onWebappsClose: function onWebappsClose(type, packet) {
-    emit(this, "webappsClose", {
+  onAppClose: function onAppClose(type, packet) {
+    emit(this, "appClose", {
       manifestURL: packet.manifestURL
     });
   },

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -32,6 +32,8 @@ const Geolocation = Cc["@mozilla.org/geolocation;1"].getService(Ci.nsISupports);
 dbgClient.UnsolicitedNotifications.geolocationStart = "geolocationStart";
 dbgClient.UnsolicitedNotifications.geolocationStop = "geolocationStop";
 dbgClient.UnsolicitedNotifications.appUpdateRequest = "appUpdateRequest";
+dbgClient.UnsolicitedNotifications.webappsOpen = "webappsOpen";
+dbgClient.UnsolicitedNotifications.webappsClose = "webappsClose";
 
 // Log subprocess error and debug messages to the console.  This logs messages
 // for all consumers of the API.  We trim the messages because they sometimes
@@ -65,6 +67,16 @@ const RemoteSimulatorClient = Class({
   // (means that we can start using the client!)
   get isReady() !!this._remote,
 
+  get client() this._remote.client,
+
+  getActorForApp: function (manifestURL, callback) {
+    this.client.request({to: this._remote.webapps, type: "listApps"},
+      function (reply) {
+        let actor = reply.apps[manifestURL];
+        callback(actor);
+      });
+  },
+
   _hookInternalEvents: function () {
     // on clientConnected, register an handler to close current connection 
     // on kill and send a "listTabs" debug protocol request, finally
@@ -92,7 +104,11 @@ const RemoteSimulatorClient = Class({
     this.on("clientReady", function (remote) {
       console.debug("rsc.onClientReady");
       this._remote = remote;
-      emit(this, "ready", null);
+      // Start watching app open/close
+      this.client.request({to: this._remote.webapps, type: "watchApps"},
+        (function () {
+          emit(this, "ready", null);
+        }).bind(this));
     });
 
     // on clientClosed, untrack old remote target and emit 
@@ -246,6 +262,8 @@ const RemoteSimulatorClient = Class({
 
     client.addListener("geolocationStart", this.onGeolocationStart.bind(this));
     client.addListener("geolocationStop", this.onGeolocationStop.bind(this));
+    client.addListener("webappsOpen", this.onWebappsOpen.bind(this));
+    client.addListener("webappsClose", this.onWebappsClose.bind(this));
 
     this._registerAppUpdateRequest(client);
 
@@ -297,6 +315,18 @@ const RemoteSimulatorClient = Class({
       Geolocation.clearWatch(this._geolocationID);
       this._geolocationID = null;
     }
+  },
+
+  onWebappsOpen: function onWebappsOpen(type, packet) {
+    emit(this, "webappsOpen", {
+      manifestURL: packet.manifestURL
+    });
+  },
+
+  onWebappsClose: function onWebappsClose(type, packet) {
+    emit(this, "webappsClose", {
+      manifestURL: packet.manifestURL
+    });
   },
 
   // send a getBuildID request to the remote simulator actor

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -317,13 +317,13 @@ const RemoteSimulatorClient = Class({
     }
   },
 
-  onAppOpen: function onAppOpen(type, packet) {
+  onAppOpen: function (type, packet) {
     emit(this, "appOpen", {
       manifestURL: packet.manifestURL
     });
   },
 
-  onAppClose: function onAppClose(type, packet) {
+  onAppClose: function (type, packet) {
     emit(this, "appClose", {
       manifestURL: packet.manifestURL
     });

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -1212,9 +1212,9 @@ let simulator = module.exports = {
           if (gRunningApps.indexOf(app) != -1) {
             cb();
           } else {
-            simulator.remoteSimulator.on("webappsOpen", function listener({manifestURL}) {
+            simulator.remoteSimulator.on("appOpen", function listener({manifestURL}) {
               if (manifestURL == app.manifestURL) {
-                simulator.remoteSimulator.removeListener("webappsOpen", listener);
+                simulator.remoteSimulator.removeListener("appOpen", listener);
                 cb();
               }
             });
@@ -1287,7 +1287,7 @@ let simulator = module.exports = {
       }
     });
 
-    remoteSimulator.on("webappsOpen", (function ({ manifestURL }) {
+    remoteSimulator.on("appOpen", (function ({ manifestURL }) {
       let app = this._getAppByManifestURL(manifestURL);
 
       // Ignore apps not being tracked by the simulator
@@ -1298,7 +1298,7 @@ let simulator = module.exports = {
       gRunningApps.push(app);
     }).bind(this));
 
-    remoteSimulator.on("webappsClose", (function ({ manifestURL }) {
+    remoteSimulator.on("appClose", (function ({ manifestURL }) {
       let app = this._getAppByManifestURL(manifestURL);
 
       // Ignore apps not being tracked by the simulator

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -38,6 +38,7 @@ const TEST_RECEIPT_URL = "https://marketplace.firefox.com/api/v1/receipts/test/"
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
+const { gDevTools } = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
 
 // NOTE: detect if developer toolbox feature can be enabled
 const HAS_CONNECT_DEVTOOLS = xulapp.is("Firefox") &&
@@ -1030,8 +1031,9 @@ let simulator = module.exports = {
       },
       set: function (target, name, v) {
         // Prevent `this._transport = null;`
-        if (name == "_transport")
+        if (name == "_transport") {
           return false;
+        }
         target[name] = v;
       }
     });
@@ -1043,7 +1045,6 @@ let simulator = module.exports = {
         client: clientProxy,
         chrome: false
       };
-      let {gDevTools} = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
 
       // Devtools API changed at each 3 last FF version :'(
       // Either on how to load modules, or how to use the API.
@@ -1307,8 +1308,9 @@ let simulator = module.exports = {
       }
 
       let idx = gRunningApps.indexOf(app);
-      if (idx != -1)
+      if (idx != -1) {
         gRunningApps.splice(idx, 1);
+      }
 
       // Close the current toolbox if it targets the closed app
       if (gCurrentToolboxManifestURL == manifestURL) {

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -55,6 +55,7 @@ const MANIFEST_CONTENT_TYPE = "application/x-web-app-manifest+json";
 
 let worker, remoteSimulator;
 let deviceConnected, adbReady, debuggerReady;
+let gCurrentToolbox, gCurrentToolboxManifestURL;
 
 let simulator = module.exports = {
   QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver,
@@ -150,9 +151,11 @@ let simulator = module.exports = {
       console.log("Selected " + manifestFile);
 
       let apps = simulator.apps;
+      let xkey = UUID.uuid().toString().slice(1, -1);
       apps[manifestFile] = {
         type: "local",
-        xkey: UUID.uuid().toString().slice(1, -1),
+        xkey: xkey,
+        origin: "app://" + xkey,
         receipt: null,
         receiptType: receiptType,
       };
@@ -975,28 +978,90 @@ let simulator = module.exports = {
     }
   },
 
-  openConnectDevtools: function() {
-    let port = this.remoteSimulator.remoteDebuggerPort;
-    let originalPort = Services.prefs.getIntPref("devtools.debugger.remote-port");
-    Tabs.open({
-      url: "chrome://browser/content/devtools/connect.xhtml",
-      onReady: function(tab) {
-        // Inject the allocated remote debugger port into the opened tab.
-        // We know it's a Number, so we don't actually need to parseInt it,
-        // but doing so reassures AMO reviewers that we aren't exposing
-        // a security issue.
-        tab.attach({
-          contentScript: "window.addEventListener(" +
-                         "  'load', " +
-                         "  function() " +
-                         "    document.getElementById('port').value = " +
-                         "      '" + parseInt(port, 10) + "', " +
-                         "  true" +
-                         ");"
-        }).on('detach', function restoreOriginalRemotePort() {
-          // restore previous value (autosaved on submit by connect.xhtml)
-          Services.prefs.setIntPref("devtools.debugger.remote-port", originalPort);
+  connectToApp: function(app) {
+    if (gCurrentToolbox) {
+      gCurrentToolbox.destroy();
+      gCurrentToolbox = null;
+    }
+    gCurrentToolboxManifestURL = app.manifestURL;
+
+    // We need to workaround existing devtools TabTarget.destroy code,
+    // that tries to close the client when the related toolbox is closed
+    // whereas we want to keep the client alive for other usages!
+    // http://hg.mozilla.org/mozilla-central/annotate/cfcce7c5eb74/browser/devtools/framework/target.js#l427
+    // TODO: remove this workaround when bug 875104 reach release channel
+    let clientProxy = new Proxy(this.remoteSimulator.client, {
+      get: function (target, name) {
+        if (name == "close")
+          return function () {};
+        return target[name];
+      }
+    });
+    let self = this;
+    this.remoteSimulator.getActorForApp(app.manifestURL, function (actor) {
+      let options = {
+        form: actor,
+        client: clientProxy,
+        chrome: false
+      };
+      let {gDevTools} = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
+
+      // Devtools API changed at each 3 last FF version :'(
+      // Either on how to load modules, or how to use the API.
+      try {
+        let devtools;
+        try {
+          // FF24
+          devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
+        } catch(e) {
+          // FF23
+          devtools = Cu.import("resource:///modules/devtools/gDevTools.jsm", {}).devtools;
+        }
+        let promise = devtools.TargetFactory.forRemoteTab(options).then(function (target) {
+          // We have to set tab as BottomHost expect a tab attribute on target whereas
+          // TabTarget ignores any tab being given as options attributes passed to forRemoteTab.
+          let browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+          Object.defineProperty(target, "tab", {value: browserWindow.gBrowser.selectedTab});
+
+          let promise = gDevTools.showToolbox(target, "webconsole", devtools.Toolbox.HostType.BOTTOM);
+          promise.then(function (toolbox) {
+            gCurrentToolbox = toolbox;
+          });
         });
+      } catch(e) {
+        let TargetFactory = Cu.import("resource:///modules/devtools/Target.jsm", {}).TargetFactory;
+        let Toolbox = Cu.import("resource:///modules/devtools/Toolbox.jsm", {}).Toolbox;
+        if (TargetFactory.forRemote) {
+          // FF21
+          let target = TargetFactory.forRemote(options.form, options.client, options.chrome);
+
+          // We have to set tab as BottomHost expect a tab attribute on target whereas
+          // TabTarget ignores any tab being given as options attributes passed to forRemoteTab.
+          let browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+          Object.defineProperty(target, "tab", {value: browserWindow.gBrowser.selectedTab});
+
+          // XXX: For some unknown reason, the toolbox doesn't get unregistered
+          // on close. Workaround that by manually unregistering it.
+          gDevTools._toolboxes.delete(target);
+
+          let promise = gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.BOTTOM);
+          promise.then(function (toolbox) {
+            gCurrentToolbox = toolbox;
+          });
+        } else {
+          // FF22
+          let target = TargetFactory.forTab(options);
+          // We have to set tab as BottomHost expect a tab attribute on target whereas
+          // TabTarget ignores any tab being given as options attributes passed to forRemoteTab.
+          let browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+          Object.defineProperty(target, "tab", {value: browserWindow.gBrowser.selectedTab});
+          target.makeRemote(options).then(function() {
+            let promise = gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.BOTTOM);
+            promise.then(function (toolbox) {
+              gCurrentToolbox = toolbox;
+            });
+          });
+        }
       }
     });
   },
@@ -1163,10 +1228,59 @@ let simulator = module.exports = {
       },
       onExit: function () {
         simulator.postIsRunning();
+
+        // Close any still opened toolbox
+        if (gCurrentToolbox) {
+          gCurrentToolbox.destroy();
+          gCurrentToolbox = null;
+        }
       }
     });
 
+    remoteSimulator.on("webappsOpen", (function ({ manifestURL }) {
+      let app = this._getAppByManifestURL(manifestURL);
+
+      // Ignore apps not being tracked by the simulator
+      if (!app) {
+        return;
+      }
+
+      app.opened = true;
+
+      // Update the connect button in app list
+      simulator.sendListApps();
+    }).bind(this));
+
+    remoteSimulator.on("webappsClose", (function ({ manifestURL }) {
+      let app = this._getAppByManifestURL(manifestURL);
+
+      // Ignore apps not being tracked by the simulator
+      if (!app) {
+        return;
+      }
+
+      app.opened = false;
+
+      // Update the connect button in app list
+      simulator.sendListApps();
+
+      // Close the current toolbox if it targets the closed app
+      if (gCurrentToolboxManifestURL == manifestURL) {
+        gCurrentToolbox.destroy();
+        gCurrentToolbox = null;
+      }
+    }).bind(this));
+
     return remoteSimulator;
+  },
+
+  _getAppByManifestURL: function (manifestURL) {
+    for (let id in this.apps) {
+      let app = this.apps[id];
+      if (app.manifestURL == manifestURL)
+        return app;
+    }
+    return null;
   },
 
   observe: function(subject, topic, data) {
@@ -1244,6 +1358,10 @@ let simulator = module.exports = {
             }
           }
         });
+        break;
+      case "connectToApp":
+        app = this.apps[message.id];
+        simulator.connectToApp(app);
         break;
       case "removeApp":
         this.removeApp(message.id);

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -948,7 +948,19 @@ let simulator = module.exports = {
       gCurrentToolbox = null;
     }
     gCurrentToolboxManifestURL = app.manifestURL;
+    // Function called whenever the toolbox is finally created
+    function toolboxDisplayed(toolbox) {
+      gCurrentToolbox = toolbox;
 
+      // Display a message in the console to make it clear that the toolbox
+      // got connected to a new App
+      let ui = toolbox.getPanel("webconsole").hud.ui;
+      let CATEGORY_JS = 2;
+      let SEVERITY_INFO = 2;
+      let node = ui.createMessageNode(CATEGORY_JS, SEVERITY_INFO,
+                                      "The toolbox is now connected to " + app.name);
+      ui.outputMessage(CATEGORY_JS, node);
+    }
     // We need to workaround existing devtools TabTarget.destroy code,
     // that tries to close the client when the related toolbox is closed
     // whereas we want to keep the client alive for other usages!
@@ -988,9 +1000,7 @@ let simulator = module.exports = {
           Object.defineProperty(target, "tab", {value: browserWindow.gBrowser.selectedTab});
 
           let promise = gDevTools.showToolbox(target, "webconsole", devtools.Toolbox.HostType.BOTTOM);
-          promise.then(function (toolbox) {
-            gCurrentToolbox = toolbox;
-          });
+          promise.then(toolboxDisplayed);
         });
       } catch(e) {
         let TargetFactory = Cu.import("resource:///modules/devtools/Target.jsm", {}).TargetFactory;
@@ -1009,9 +1019,7 @@ let simulator = module.exports = {
           gDevTools._toolboxes.delete(target);
 
           let promise = gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.BOTTOM);
-          promise.then(function (toolbox) {
-            gCurrentToolbox = toolbox;
-          });
+          promise.then(toolboxDisplayed);
         } else {
           // FF22
           let target = TargetFactory.forTab(options);
@@ -1021,9 +1029,7 @@ let simulator = module.exports = {
           Object.defineProperty(target, "tab", {value: browserWindow.gBrowser.selectedTab});
           target.makeRemote(options).then(function() {
             let promise = gDevTools.showToolbox(target, "webconsole", Toolbox.HostType.BOTTOM);
-            promise.then(function (toolbox) {
-              gCurrentToolbox = toolbox;
-            });
+            promise.then(toolboxDisplayed);
           });
         }
       }

--- a/prosthesis/content/dbg-webapps-actors.js
+++ b/prosthesis/content/dbg-webapps-actors.js
@@ -395,7 +395,7 @@ WebappsActor.prototype = {
         this._framesByOrigin[origin] = frame;
 
         this.conn.send({ from: this.actorID,
-                         type: "webappsOpen",
+                         type: "appOpen",
                          manifestURL: frame.getAttribute("mozapp"),
                          actor: actor.grip()
                        });
@@ -414,7 +414,7 @@ WebappsActor.prototype = {
           }
           let manifestURL = frame.getAttribute("mozapp");
           this.conn.send({ from: this.actorID,
-                           type: "webappsClose",
+                           type: "appClose",
                            manifestURL: manifestURL
                          });
         }

--- a/prosthesis/content/dbg-webapps-actors.js
+++ b/prosthesis/content/dbg-webapps-actors.js
@@ -293,7 +293,7 @@ WebappsActor.prototype = {
     return { appId: appId, path: appDir.path }
   },
 
-  _createAppActor: function wa__createAppActor(frame) {
+  _createAppActor: function (frame) {
     // Eventually retrieve a previous Actor instance for this app
     let actor = this._appActorsMap.get(frame);
     if (!actor) {
@@ -307,7 +307,7 @@ WebappsActor.prototype = {
     return actor;
   },
 
-  listApps : function wa_onListApps() {
+  listApps : function () {
     let actorPool = new ActorPool(this.conn);
 
     // Store a dictionary of app actors indexed by their manifest URL.
@@ -327,7 +327,7 @@ WebappsActor.prototype = {
 
     // Register apps hosted in the system app. (i.e. all regular apps)
     let frames = systemAppFrame.contentDocument.querySelectorAll("iframe[mozapp]");
-    for(var i = 0; i < frames.length; i++) {
+    for (let i = 0; i < frames.length; i++) {
       let frame = frames[i];
       registerApp.call(this, frame);
     }
@@ -345,7 +345,7 @@ WebappsActor.prototype = {
     };
   },
 
-  watchApps: function wa_watchApps() {
+  watchApps: function () {
     let chromeWindow = Services.wm.getMostRecentWindow('navigator:browser');
     let systemAppFrame = chromeWindow.getContentWindow();
     // Eventually drop the pool being used during the last call to watchApps
@@ -361,7 +361,7 @@ WebappsActor.prototype = {
     return {};
   },
 
-  unwatchApps: function wa_unwatchApps() {
+  unwatchApps: function () {
     let chromeWindow = Services.wm.getMostRecentWindow('navigator:browser');
     let systemAppFrame = chromeWindow.getContentWindow();
     // Eventually drop the pool being used during the last call to watchApps
@@ -447,7 +447,7 @@ function AppActor(connection, browser, appActorsMap) {
 
 AppActor.prototype = new BrowserTabActor();
 
-AppActor.prototype._attach = function DTA_attach() {
+AppActor.prototype._attach = function () {
   if (this._attached) {
     return;
   }
@@ -461,7 +461,7 @@ AppActor.prototype._attach = function DTA_attach() {
   // One actor can only be attached once and then be garbaged on detach.
   this._appActorsMap.delete(this.browser);
 }
-AppActor.prototype._detach = function DTA_detach() {
+AppActor.prototype._detach = function () {
   if (!this.attached) {
     return;
   }
@@ -470,14 +470,14 @@ AppActor.prototype._detach = function DTA_detach() {
   BrowserTabActor.prototype._detach.call(this);
 }
 
-AppActor.prototype.observe = function DTA_observe(subject, topic, data) {
+AppActor.prototype.observe = function (subject, topic, data) {
   if (subject.wrappedJSObject == this.browser.contentWindow.wrappedJSObject) {
     let event = {target: subject.document, type: "DOMWindowCreated"};
     this.onWindowCreated(event);
   }
 }
 
-AppActor.prototype.grip = function DTA_grip() {
+AppActor.prototype.grip = function () {
   dbg_assert(!this.exited,
              'grip() should not be called on exited browser actor.');
   dbg_assert(this.actorID,
@@ -505,7 +505,7 @@ AppActor.prototype.grip = function DTA_grip() {
  * Creates a thread actor and a pool for context-lifetime actors. It then sets
  * up the content window for debugging.
  */
-AppActor.prototype._pushContext = function DTA_pushContext() {
+AppActor.prototype._pushContext = function () {
   dbg_assert(!this._contextPool, "Can't push multiple contexts");
 
   this._contextPool = new ActorPool(this.conn);
@@ -521,7 +521,7 @@ AppActor.prototype._pushContext = function DTA_pushContext() {
 /**
  * Prepare to enter a nested event loop by disabling debuggee events.
  */
-AppActor.prototype.preNest = function DTA_preNest() {
+AppActor.prototype.preNest = function () {
   let windowUtils = this.browser.contentWindow
                         .QueryInterface(Ci.nsIInterfaceRequestor)
                         .getInterface(Ci.nsIDOMWindowUtils);
@@ -532,7 +532,7 @@ AppActor.prototype.preNest = function DTA_preNest() {
 /**
  * Prepare to exit a nested event loop by enabling debuggee events.
  */
-AppActor.prototype.postNest = function DTA_postNest(aNestData) {
+AppActor.prototype.postNest = function (aNestData) {
   let windowUtils = this.browser.contentWindow
                         .QueryInterface(Ci.nsIInterfaceRequestor)
                         .getInterface(Ci.nsIDOMWindowUtils);


### PR DESCRIPTION
So here is the work I was mentioning in PR #567 https://github.com/mozilla/r2d2b2g/pull/567#issuecomment-19115271

This is a more substantial patch, but with a lot more value.
It introduces a `connect` button next to each app that is displayed/hidden whenever the app is opened/closed. Once you click on this button, a remote devtool toolbox is being displayed as a regular web one, in the same window as a "bottom bar".
Then, if you close the simulation or close the app the toolbox is automatically closed.
If you click on another app `connect` button, a new one connected to the related app replace the eventual current toolbox.

In order to do that, instead of hacking `dbg-browser-actor.js` I decided to add new requests in `dbg-webapps-actor.js` in order to stop hacking around tabs and finally provide access to apps through dedicated `apps` keywords (So I copy pasted a piece of dbg-browser-actor, mainly `AppActor`)
Also, I tried to come up with modifications that would be easily upstreamed to firefox codebase. Moving apps stuff out of `listTabs` request is particularely important regarding firefox as we will most likely not always care about apps, so that building apps actors on each remote connection startup would be in most cases unecessary (listTabs is requested on each connection startup).

So, the webapps actors gained 3 methods:
- `listApps`, that returns a dictionary of all current opened app actors, indexed by they manifest URL.
- `watchApps`, order the webapps actor to start watching for app opening/closing. The actor is going to dispatch `webappsOpen`/`webappsClose` events.
- `unwatchApps, order the actor to stop listening for webapps opening/closing.

Finally, there is this challenging piece of code that aims to open the toolbox on all 4 current Firefox versions. It includes some hacks in order to make work the toolbox as a "bottom bar" and a bunch of conditional code in order to match every subtle differences around target and toolbox we have over firefox releases.
