### PR TITLE
change Receipt Type label to Receipt

### DIFF
--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -52,7 +52,7 @@
                 <section id="add-project-dialog">
                     <ul class="list-actions">
                         <li>
-                            <label for="receipt_type">Receipt Type:</label>
+                            <label for="receipt_type">Receipt:</label>
                             <select name="receipt_type" id="receipt_type">
                                 <option value="none" selected>None</option>
                                 <option value="ok">Valid</option>
@@ -90,7 +90,7 @@
         <script type="text/template" id="app-template">
             <li class="app {{ 'removed' if removed }}" data-id="{{ id | escape }}">
                 <div class="options">
-                    <label>Receipt Type</label>
+                    <label>Receipt:</label>
                     <select class="receipt-type">
                         {% for type in receiptTypes %}
                             <option value="{{ type }}" {{ 'selected' if receiptType == type else '' }}>{{ type }}</option>


### PR DESCRIPTION
The "Receipt Type" label is accurate, since it is the type of receipt that is being selected, not the receipt itself. But it isn't necessary to be this accurate, since users can grok the incongruence between the word "receipt" and the types listed in the menu; and it takes up extra space to include the word "type" in a space-constrained UI. So we should label this menu simply "Receipt", which is accurate enough and takes up less space.
