### PR TITLE
Always fetch latest manfiest.webapp when you click "Update"  on a Hosted App.

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -771,7 +771,7 @@ let simulator = module.exports = {
       break;
     case "hosted":
       Request({
-        url: id,
+        url: id + '?' + new Date().getTime(), // append microtime to avoid cache
         onComplete: function (response) {
           let error;
           if (response.status != 200) {


### PR DESCRIPTION
Avoid hitting cache on issue #617.

There could be a better way to do avoid the cache hit. This is just the simplest I could think of.
