### PR TITLE
remove obsolete console & default app options (fixes #622)

### DIFF
--- a/addon/data/content/css/main.css
+++ b/addon/data/content/css/main.css
@@ -170,17 +170,6 @@ figure {
     text-decoration: none;
 }
 
-.commands-options {
-    display: block;
-    margin-top: 10px;
-    line-height: 1.4em;
-    font-size: 0.8em;
-    color: #888;
-}
-.commands-options input {
-    margin-right: 5px;
-}
-
 .toggle {
     position: relative;
     border: 1px solid rgba(0, 0, 0, 0.4);

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -25,21 +25,6 @@
                                 <span class="toggle-off">Running</span>
                             </span>
                         </label>
-                        <label class="commands-options">
-                            <input type="checkbox" id="commands-preference-jsconsole" />Console
-                        </label>
-                        <label class="commands-options" style="display: none">
-                            <div id="show-debugger-port">
-                              Remote Debugger Port:
-                              <span id="commands-preference-remote-debugger-port"></span>
-                            </div>
-                            <button id="open-connect-devtools" title="Connect Developer Tools&hellip;"
-                                    onclick="Simulator.openConnectDevtools()">Connect&hellip;</button>
-                        </label>
-                        <label class="commands-options" style="display: none">
-                          Run:
-                          <span id="commands-preference-default-app"></span>
-                        </label>
                     </fieldset>
                 </div>
                 <h5 id="device-status" class="device-dependent">

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -25,6 +25,10 @@
                                 <span class="toggle-off">Running</span>
                             </span>
                         </label>
+                        <button id="open-connect-devtools" title="Connect Developer Tools&hellip;"
+                                onclick="Simulator.openConnectDevtools()" style="display: none">
+                            Connect&hellip;
+                        </button>
                     </fieldset>
                 </div>
                 <h5 id="device-status" class="device-dependent">

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -32,14 +32,6 @@ var Simulator = {
       window.postMessage({name: "validateUrl", url: url}, "*");
     });
 
-    $('#commands-preference-jsconsole').on('change', function(evt) {
-      window.postMessage({
-        name: "setPreference",
-        key: "jsconsole",
-        value: $(this).prop("checked")
-      }, "*");
-    });
-
     $('#form-add-app').on('submit', function(evt) {
       evt.preventDefault();
 
@@ -69,28 +61,7 @@ var Simulator = {
             break;
           case "isRunning":
             $(Simulator.toggler).prop('indeterminate', false);
-            var remoteDebuggerPortEl = $('#commands-preference-remote-debugger-port');
-            if (message.isRunning) {
-              $(Simulator.toggler).prop('checked', true);
-              remoteDebuggerPortEl.html(message.remoteDebuggerPort);
-              remoteDebuggerPortEl.parents('label').show();
-              // NOTE: show connect devtools buttons where it's supported
-              //       and show allocated debugger port on previous firefox releases
-              if (message.hasConnectDevtools) {
-                $("#show-debugger-port").hide();
-                $("#open-connect-devtools").prop("disabled", false);
-                $("#open-connect-devtools").show();
-              } else {
-                $("#show-debugger-port").show();
-                $("#open-connect-devtools").hide();
-                $("#open-connect-devtools").prop("disabled", true);
-              }
-            }
-            else {
-              $(Simulator.toggler).prop('checked', false);
-              $('#commands-preference-remote-debugger-port').html(message.remoteDebuggerPort);
-              remoteDebuggerPortEl.parents('label').hide();
-            }
+            $(Simulator.toggler).prop('checked', message.isRunning);
             break;
           case "listTabs":
             var datalist = $('#list-app-tabs').empty();
@@ -101,9 +72,6 @@ var Simulator = {
               datalist.append(el);
               tablist.append(el);
             }
-            break;
-          case "setPreference":
-            $("#commands-preference-" + message.key).prop("checked", message.value);
             break;
           case "validateUrl":
             var set = $('#add-app-url').parents('form').removeClass('is-manifest');
@@ -117,14 +85,6 @@ var Simulator = {
             }
             break;
           case "listApps":
-            var defaultApp = message.defaultApp || null;
-
-            var defaultPref = $("#commands-preference-default-app");
-            if (defaultApp) {
-              defaultPref.text(message.list[defaultApp].name).parents('label').show();
-            } else {
-              defaultPref.parents('label').hide();
-            }
             AppList.update(message.list);
             break;
         }
@@ -137,7 +97,6 @@ var Simulator = {
     // Clears removed apps on reload
     window.postMessage({ name: "listApps", flush: true }, "*");
     window.postMessage({ name: "listTabs" }, "*");
-    window.postMessage({ name: "getPreference" }, "*");
   },
 
   updateDeviceView: function() {

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -62,6 +62,11 @@ var Simulator = {
           case "isRunning":
             $(Simulator.toggler).prop('indeterminate', false);
             $(Simulator.toggler).prop('checked', message.isRunning);
+            if (message.isRunning) {
+              $("#open-connect-devtools").show().prop("disabled", false);
+            } else {
+              $("#open-connect-devtools").hide().prop("disabled", true);
+            }
             break;
           case "listTabs":
             var datalist = $('#list-app-tabs').empty();

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -17,6 +17,7 @@ const Request = require('request').Request;
 const SStorage = require("simple-storage");
 const Gcli = require('gcli');
 const Simulator = require("simulator.js");
+const Prefs = require("preferences-service");
 
 Cu.import("resource://gre/modules/Services.jsm");
 
@@ -78,6 +79,12 @@ if (SStorage.storage.lastVersion != Self.version) {
 // - ensure apps xkeys are unique
 // - flag needsUpdateAll if there are active apps registered
 if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
+  // Delete obsolete property and preference.
+  if (Services.vc.compare(lastVersion, "4.0pre7") < 0) {
+    delete SStorage.storage.defaultApp;
+    Prefs.delete("extensions.r2d2b2g.jsconsole");
+  }
+
   if (Simulator.apps) {
     let activeAppIds = Object.keys(Simulator.apps).
       filter(function (appId) !Simulator.apps[appId].deleted);

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -82,7 +82,7 @@ if (["install", "downgrade", "upgrade"].indexOf(Self.loadReason) >= 0) {
   // Delete obsolete property and preference.
   if (Services.vc.compare(lastVersion, "4.0pre7") < 0) {
     delete SStorage.storage.defaultApp;
-    Prefs.delete("extensions.r2d2b2g.jsconsole");
+    Prefs.reset("extensions.r2d2b2g.jsconsole");
   }
 
   if (Simulator.apps) {

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -17,7 +17,6 @@ const Runtime = require("runtime");
 const Self = require("self");
 const URL = require("url");
 const Subprocess = require("subprocess");
-const Prefs = require("preferences-service");
 const { setTimeout, clearTimeout } = require("sdk/timers");
 
 const { rootURI: ROOT_URI } = require('@loader/options');
@@ -27,6 +26,8 @@ const PROFILE_URL = ROOT_URI + "profile/";
 const dbgClient = Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 
 const Geolocation = Cc["@mozilla.org/geolocation;1"].getService(Ci.nsISupports);
+
+const DEBUGGER_CONNECT_TIMEOUT = 30000;
 
 // add unsolicited notifications
 dbgClient.UnsolicitedNotifications.geolocationStart = "geolocationStart";
@@ -104,8 +105,7 @@ const RemoteSimulatorClient = Class({
         // If the connection was closed before connection succeed,
         // and the process is still alive, the attempt was rejected or timed out.
         // We should keep trying to connect until we reach our own timeout.
-        let timeout = this._timeout || 30000;
-        if (Date.now() - this._startConnectingTime < timeout) {
+        if (Date.now() - this._startConnectingTime < DEBUGGER_CONNECT_TIMEOUT) {
           setTimeout(this.connectDebuggerClient.bind(this), 250);
         }
         else {
@@ -126,20 +126,10 @@ const RemoteSimulatorClient = Class({
     this.on("stderr", function onStderr(data) console.error(data.trim()));
   },
 
-  // run({defaultApp: "Appname", timeout: 15000})
-  // will spawn a b2g instance, optionally run an application
-  // and change pingback timeout interval
-  run: function (options) {
-    if (options) {
-      this._defaultApp = options.defaultApp;
-      this._timeout = options.timeout;
-      delete options.defaultApp;
-      delete options.pingbackTimeout;
-    } else {
-      this._defaultApp = null;
-      this._timeout = null;
-    }
-
+  /**
+   * Start the process and connect the debugger client.
+   */
+  run: function() {
     // resolve b2g binaries path (raise exception if not found)
     let b2gExecutable = this.b2gExecutable;
 
@@ -446,14 +436,6 @@ const RemoteSimulatorClient = Class({
     // NOTE: push dbgport option on the b2g-desktop commandline
     args.push("-dbgport", ""+this.remoteDebuggerPort);
     
-    if (this.jsConsoleEnabled) {
-      args.push("-jsconsole");
-    }
-
-    if (this._defaultApp != null) {
-      args.push("--runapp", this._defaultApp);
-    }
-
     // Ignore eventual zombie instances of b2g that are left over
     args.push("-no-remote");
 
@@ -484,9 +466,6 @@ const RemoteSimulatorClient = Class({
     this._foundRemoteDebuggerPort = port;
   },
 
-  get jsConsoleEnabled() {
-    return Prefs.get("extensions.r2d2b2g.jsconsole", false);    
-  }
 });
 
 module.exports = RemoteSimulatorClient;

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -39,13 +39,6 @@ const TEST_RECEIPT_URL = "https://marketplace.firefox.com/api/v1/receipts/test/"
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
-// NOTE: detect if developer toolbox feature can be enabled
-const HAS_CONNECT_DEVTOOLS = xulapp.is("Firefox") &&
-  xulapp.versionInRange(xulapp.platformVersion, "20.0a1", "*");
-
-console.debug("XULAPP: ", xulapp.name,xulapp.version, xulapp.platformVersion);
-console.debug("HAS_CONNECT_DEVTOOLS: ", HAS_CONNECT_DEVTOOLS);
-
 const PR_RDWR = 0x04;
 const PR_CREATE_FILE = 0x08;
 const PR_TRUNCATE = 0x20;
@@ -93,18 +86,6 @@ let simulator = module.exports = {
 
   get permissions() {
     return SStorage.storage.permissions || (SStorage.storage.permissions = {});
-  },
-
-  get defaultApp() {
-    return SStorage.storage.defaultApp || null;
-  },
-
-  set defaultApp(id) {
-    SStorage.storage.defaultApp = id;
-  },
-
-  get jsConsoleEnabled() {
-    return Prefs.get("extensions.r2d2b2g.jsconsole", false);
   },
 
   get worker() worker,
@@ -346,9 +327,6 @@ let simulator = module.exports = {
                          " (packaged app) installed in Firefox OS");
           // Complete install (Packaged)
 
-          // NOTE: remote simulator.defaultApp because on the first run the app
-          //       will be not already installed
-          simulator.defaultApp = null;
           console.log("Requesting webappsActor to install packaged app: ",
                       config.xkey);
           simulator.run(function(error) {
@@ -413,8 +391,6 @@ let simulator = module.exports = {
               simulator.info(config.name + " (hosted app) installed in Firefox OS");
 
               // Complete install (Hosted)
-              // DISABLED: because on the first run the app will be not already installed
-              simulator.defaultApp = null;
               simulator.run(function(error) {
                 if (error) {
                   // exit on error running b2g-desktop
@@ -866,7 +842,6 @@ let simulator = module.exports = {
     this.worker.postMessage({
       name: "listApps",
       list: simulator.apps,
-      defaultApp: simulator.defaultApp
     });
   },
 
@@ -994,21 +969,7 @@ let simulator = module.exports = {
     }
   },
 
-  getPreference: function() {
-    this.worker.postMessage({
-      name: "setPreference",
-      key: "jsconsole",
-      value: simulator.jsConsoleEnabled
-    });
-  },
-
   run: function (cb) {
-    let appName = null;
-    if (this.defaultApp) {
-      appName = this.apps[this.defaultApp].name
-      this.defaultApp = null;
-    }
-
     let next = null;
     // if needsUpdateAll try to reinstall all active registered app
     if (SStorage.storage.needsUpdateAll) {
@@ -1037,9 +998,7 @@ let simulator = module.exports = {
       });
 
       try {
-        this.remoteSimulator.run({
-          defaultApp: appName
-        });
+        this.remoteSimulator.run();
       } catch(e) {
         if (!cb) {
           // report error if simulator.run is called
@@ -1074,15 +1033,9 @@ let simulator = module.exports = {
 
   postIsRunning: function() {
     if (simulator.worker) {
-      let port = simulator.isRunning ?
-        simulator.remoteSimulator.remoteDebuggerPort :
-        null;
-
       simulator.worker.postMessage({
         name: "isRunning",
         isRunning: simulator.isRunning,
-        remoteDebuggerPort: port,
-        hasConnectDevtools: HAS_CONNECT_DEVTOOLS,
       });
     }
   },
@@ -1190,18 +1143,6 @@ let simulator = module.exports = {
         break;
       case "undoRemoveApp":
         this.undoRemoveApp(message.id);
-        break;
-      case "setDefaultApp":
-        if (!message.id || message.id in apps) {
-          simulator.defaultApp = message.id;
-          this.sendListApps();
-        }
-        break;
-      case "setPreference":
-        console.log(message.key + ": " + message.value);
-        Prefs.set("extensions.r2d2b2g." + message.key, message.value);
-      case "getPreference":
-        simulator.getPreference();
         break;
       case "toggle":
         if (this.isRunning) {


### PR DESCRIPTION
Originally I planned to remove just the console checkbox, but then I noticed there is other cruft in the code, i.e. functionality that we don't use anymore, in particular for specifying a "default app" on the b2g command line, so I removed that too. Which entrained additional code removal, like the (unused) ability to set a remote debugger client timeout in the options to _RemoteSimulatorClient.run_.

Originally I also planned to replace the checkbox with a hidden pref to enable/disable the Error Console, but then I realized that a remote toolbox connected to the "global process" will show chrome messages, including extension messages from prosthesis. So I don't think the Error Console is actually useful to anyone, not even Simulator developers, since we can connect remote tools to the global process to see these messages.

I also removed the code that displays the remote debugger port on the Dashboard if you're using Firefox 19 or older, since we only support Firefox versions from our four main distribution channels, which are currently 21-24.

There are probably some conflicts between these changes and the ones in the "toolbox per app" branch, but hopefully they are relatively minor and easy to resolve.
