### PR TITLE
Simulator unloads on last tab, so adb can unload. Fixes #641

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -112,7 +112,7 @@ Tabs.on('ready', function() {
 Tabs.on('close', function() {
   // Kill process when the last tab is gone
   if (!Tabs.length) {
-    Simulator.kill();
+    Simulator.unload();
   }
   if (Simulator.worker) {
     Simulator.sendListTabs();

--- a/addon/test/test-main.js
+++ b/addon/test/test-main.js
@@ -1,6 +1,5 @@
-
 exports.test_run = function(test) {
-  var main = require("main");
+  const main = require("main");
   test.pass("Unit test running!");
 };
 

--- a/addon/test/test-main.js
+++ b/addon/test/test-main.js
@@ -1,6 +1,6 @@
-var main = require("main");
 
 exports.test_run = function(test) {
+  var main = require("main");
   test.pass("Unit test running!");
 };
 

--- a/addon/test/test-receipts.js
+++ b/addon/test/test-receipts.js
@@ -5,7 +5,6 @@
 const { getActiveTab, getTabContentWindow, closeTab } = require("sdk/tabs/utils");
 const { getMostRecentBrowserWindow } = require("sdk/window/utils");
 const { nsHttpServer } = require("sdk/test/httpd");
-const simulator = require("simulator");
 
 const MOCK_MANIFEST_URL = "http://localhost:8099/test_app/webapp.manifest";
 
@@ -77,6 +76,7 @@ function cleanUp({ srv, window, done, simulator }) {
 }
 
 exports["test receipt update"] = function receiptUpdate(assert, done) {
+  const simulator = require("simulator");
 
   // Start up a test serving serving a locally hosted app.
   let srv = new nsHttpServer();


### PR DESCRIPTION
Thanks for help narrowing down this bug @nickdesaulniers!

This patch makes `adb` be killed like it's supposed to after running `make test`.
`adb.js` was being loaded twice because:
`1) require("main") -> require("simulator") -> require("adb") // in test-main.js`
and
`2) require("simulator") -> require("adb") // in test-receipts`

This seemed reasonable, but it looks like we have to move those two top-level requires inside of the test cases so that the second loading executes completely after the first one. Also, we weren't killing `adb` after the last tab was closed (parameter-less unload will do `Simulator.kill` and will kill `adb` if necessary)
