### PR TITLE
disable DOM battery API (fixes #536)

### DIFF
--- a/build/override-prefs.js
+++ b/build/override-prefs.js
@@ -2,10 +2,3 @@
 // prosthesis/defaults/preferences/prefs.js, but these load earlier, so this
 // file is useful for prefs that are accessed before addons are loaded.
 
-// Disable the battery API so Gaia doesn't shut down the Simulator on machines
-// with a dead or missing battery that it misinterprets as a low power state.
-//
-// This has to be here to affect the state of BatteryManager, which checks it
-// before addons have loaded.
-//
-user_pref("dom.battery.enabled", false);

--- a/build/override-prefs.js
+++ b/build/override-prefs.js
@@ -1,0 +1,11 @@
+// Prefs that override GRE/Gaia prefs.  Note that other such prefs are in
+// prosthesis/defaults/preferences/prefs.js, but these load earlier, so this
+// file is useful for prefs that are accessed before addons are loaded.
+
+// Disable the battery API so Gaia doesn't shut down the Simulator on machines
+// with a dead or missing battery that it misinterprets as a low power state.
+//
+// This has to be here to affect the state of BatteryManager, which checks it
+// before addons have loaded.
+//
+user_pref("dom.battery.enabled", false);


### PR DESCRIPTION
This simple change sets a pref that disables the DOM battery API (navigator.battery). With this change, Gaia no longer shuts down on startup if a battery is absent on Linux (#536). However, the Settings app doesn't handle the situation perfectly, as it correctly exits early when it can't access the API, but then it tries to access it anyway and triggers an exception:

```
[22:35:47.467] Could not get window.navigator.battery
[22:35:47.468] TypeError: battery is undefined @ app://settings.gaiamobile.org/js/battery.js:68
```

And the Battery section of Settings doesn't open when I click on it. That seems ok, but it looks like I also have trouble opening Device Information after clicking Battery. No matter how many times I click on it, it doesn't open if I previously clicked on Battery.

I also have trouble getting Gaia to respond to mouse click events after dragging to scroll the app (it takes 2-3 clicks to get Gaia to register a click), and I see a ton of these errors in the console:

```
[22:35:54.697] NotSupportedError: Operation is not supported @ chrome://desktop-helper.js/content/touch-events.js:167
```

But that happens both with and without this change. So it seems like a separate issue.

In any case, it might be hard to set up a system that can reproduce #536, but it's easy to test this change, since it disables the API on all systems. I've tested it on both the Linux VM that can reproduce #536 and a Mac installation. It behaves the same on both.

Note that this change might prevent people from testing the battery API. But hooking up the Simulator to a laptop's real battery is a poor way of "simulating" the API anyway, because some users have desktops without batteries, and even users who have laptops with batteries will find it cumbersome to drain their real battery just to test their app in a low battery state.

A good simulation of the battery API would actually simulate a battery and enable the user to set the battery to any state (just like the geolocation simulation lets you set the position). We don't have that simulation yet, and in the meantime, I'm ok with disabling the API. But I'm concerned about side effects like that Device Information issue I noticed.

@ochameau What do you think about this way of fixing #536?

(Another way of fixing it would be to override the API with a custom implementation. The API is defined in WebIDL, and I'm not sure if it's possible to override such APIs. But I see that Gaia's tools/extensions/activities/components/SystemMessageManager.js implements nsIDOMNavigatorSystemMessages, so perhaps we could use a component to override nsIDOMBatteryManager.)
