### PR TITLE
Make Help a UI Button in the Header of Dashboard

### DIFF
--- a/addon/data/content/css/main.css
+++ b/addon/data/content/css/main.css
@@ -100,14 +100,6 @@ h1 {
     right: 13px;
     bottom: 13px;
 }
-#help {
-    float: right;
-    color: #888;
-    text-decoration: none;
-}
-#help:active {
-    color: #4D4E53;
-}
 
 .badge:after, .badge:before {
     content: "";
@@ -437,13 +429,18 @@ figure {
 #add-app-url {
     width: 220px;
 }
-button, input[type="url"], input[type="text"] {
+button, input[type="url"], input[type="text"], a.button {
     font-size: 0.8rem;
+    background: #f0f0f0;
     color: #444;
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 5px;
     padding: 7px 9px;
     font-weight: bold;
+    text-decoration: none;
+}
+a.button {
+    display: inline-block;
 }
 button:disabled {
     color: #999;
@@ -462,10 +459,6 @@ input:-moz-placeholder {
 button:hover:not(:disabled), .popover-wrap:hover button, a.button:hover {
     color: #1155cc;
     cursor: pointer;
-}
-a.button {
-    font-size: 0.8rem;
-    padding: 8px 12px;
 }
 .popover-wrap button {
     pointer-events: none;

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -34,7 +34,6 @@
                 <h5 id="device-status" class="device-dependent">
                     <img src="device.svg" alt="Device"> Device connected.
                 </h5>
-                <a id="help" class="item" href="https://developer.mozilla.org/en-US/docs/Tools/Firefox_OS_Simulator" target="_blank">Help</a>
             </header>
 
             <section id="dashboard">
@@ -50,6 +49,9 @@
                                 <button id="action-add-page" title="A manifest will be generated for this page." disabled>Add URL</button>
                                 <button id="action-add-manifest" title="Only enabled when the manifest is valid (JSON and correct mime type)" disabled>Add Manifest</button>
                             </form>
+                        </li>
+                        <li>
+                            <a id="help" class="item button" href="https://developer.mozilla.org/en-US/docs/Tools/Firefox_OS_Simulator" target="_blank">Help</a>
                         </li>
                     </ul>
                 </section>


### PR DESCRIPTION
Talked with Tony, his recommendation was to move Help back to the top right as a button. This does that.
