### PR TITLE
auto open dashboard for `make run` Fixes #657

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ locales:
 	python build/make-locales.py
 
 run:
-	cd addon-sdk && . bin/activate && cd ../addon && cfx run --templatedir template/ $(BIN_ARG) $(PROFILE_ARG)
+	cd addon-sdk && . bin/activate && cd ../addon && cfx run --templatedir template/ $(BIN_ARG) $(PROFILE_ARG) --static-args="{ \"autoRun\": true }"
 
 package:
 	cd addon-sdk && . bin/activate && cd ../addon && cfx xpi --templatedir template/

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -18,6 +18,7 @@ const SStorage = require("simple-storage");
 const Gcli = require('gcli');
 const Simulator = require("simulator.js");
 const Prefs = require("preferences-service");
+const Args = require("sdk/system").staticArgs;
 
 Cu.import("resource://gre/modules/Services.jsm");
 
@@ -264,4 +265,8 @@ if (PermissionSettings) {
         return "unknown";
     }
   };
+}
+
+if (Args.autoRun) {
+  Simulator.openHelperTab();
 }


### PR DESCRIPTION
review? @mykmelez

Is there a good reason why we don't do this?

Now you shouldn't need the pref to auto open tabs and windows on reopen.

What sucks is that there's still a new tab open.  Not sure what the best way to fix is?  Maybe @ochameau has some advice?
