### PR TITLE
install app on connect to app if app isn't already installed

### DIFF
--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -101,7 +101,7 @@ SimulatorActor.prototype = {
     let DOMApplicationRegistry = window.DOMApplicationRegistry;
 
     if (!DOMApplicationRegistry.webapps[appId]) {
-      return { success: false, error: 'app-not-installed', message: 'App not installed.'};
+      return false;
     }
 
     let appOrigin = DOMApplicationRegistry.webapps[appId].origin;
@@ -214,18 +214,19 @@ SimulatorActor.prototype = {
 
     Services.tm.currentThread.dispatch(runnable,
                                        Ci.nsIThread.DISPATCH_NORMAL);
+    return true;
   },
 
   onRunApp: function(aRequest) {
     this.debug("simulator actor received a 'runApp' command:" + aRequest.appId);
-    let appId = aRequest.appId;
 
-    this._runApp(appId);
+    let success = this._runApp(aRequest.appId);
 
-    return {
-      message: "runApp request received: " + appOrigin,
-      success: true
-    };
+    if (success) {
+      return { success: true, message: "runApp request initiated" };
+    } else {
+      return { success: false, error: "app-not-installed" };
+    }
   },
 
   onUninstallApp: function(aRequest) {
@@ -235,7 +236,7 @@ SimulatorActor.prototype = {
     let appId = aRequest.appId;
 
     if (!DOMApplicationRegistry.webapps[appId]) {
-      return { success: false, error: 'app-not-installed', message: 'App not installed.'}
+      return { success: false, error: 'app-not-installed' };
     }
 
     let appOrigin = DOMApplicationRegistry.webapps[appId].origin;

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -224,9 +224,8 @@ SimulatorActor.prototype = {
 
     if (success) {
       return { success: true, message: "runApp request initiated" };
-    } else {
-      return { success: false, error: "app-not-installed" };
     }
+    return { success: false, error: "app-not-installed" };
   },
 
   onUninstallApp: function(aRequest) {


### PR DESCRIPTION
This changeset makes the new "connect to app" functionality install the app while connecting to it if it isn't already installed.

It does this by making _simulator.runApp_ a fully round-trip operation that calls its _next_ callback with an error if the app isn't already installed. Then it makes _simulator.connectToApp_ call _simulator.runApp_ with a callback that calls _simulator.updateApp_ and then _simulator.runApp_ again if it receives an _app-not-installed_ error.

Along the way I simplified some code in _simulator.runApp_ and the actor script. But mostly I made the code more complex, because the code in question uses callbacks to chain asynchronous functions, which quickly becomes complex when you actually start to handle error cases instead of silently ignoring them. In the long run, we should move this code to promises to make error handling of complex asynchonous function chains simpler.
