### PR TITLE
show throbber by receipt label when updating receipt (fixes #613)

### DIFF
--- a/addon/data/content/css/main.css
+++ b/addon/data/content/css/main.css
@@ -348,6 +348,15 @@ figure {
 .receipt-type {
     padding: 1px 0;
 }
+.receipt-label {
+    padding-left: 23px;
+}
+.app.updateReceipt .receipt-label {
+    background-image: url(../throbber.svg);
+    background-repeat: no-repeat;
+    background-position: 6px center;
+    background-size: auto 14px;
+}
 #apps-list .options button, #apps-list .options a {
     padding: 4px 10px 3px;
     font-weight: normal;
@@ -383,9 +392,6 @@ figure {
 #apps-list .action[data-action=connect]:hover {
     background-image: url(../tools.svg#hover);
 }
-#apps-list label {
-    padding-left: 5px;
-}
 #apps-list input[type="checkbox"] {
 }
 #apps-list p {
@@ -393,11 +399,6 @@ figure {
     color: #888;
     margin: 0;
     margin-bottom: 2px;
-}
-#apps-list label span {
-    font-size: 0.8em;
-    color: #888;
-    padding: 0 10px;
 }
 
 #apps-list .app-validation {

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -64,7 +64,7 @@
         </article>
 
         <script type="text/template" id="app-template">
-            <li class="app {{ 'removed' if removed }}" data-id="{{ id | escape }}">
+            <li class="app {{ 'removed' if removed }} {{ 'updateReceipt' if updateReceipt }}" data-id="{{ id | escape }}">
                 <div class="options">
                     {% if removed %}
                         <button class="action" data-action="undo">Undo</button>
@@ -76,7 +76,7 @@
                         <button class="action connect" data-action="connect">Connect</button>
                         <button title="Remove" class="action remove" data-action="remove">Remove</button>
                         <div class="receipt">
-                            <label>Receipt:</label>
+                            <label class="receipt-label">Receipt:</label>
                             <select class="receipt-type">
                                 {% for type in receiptTypes %}
                                     <option value="{{ type.id }}" {{ 'selected' if receiptType == type.id else '' }}>{{ type.pretty }}</option>

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -87,6 +87,14 @@ var Simulator = {
           case "listApps":
             AppList.update(message.list);
             break;
+          case "updateReceiptStart":
+            $('li').filter(function() $(this).data('id') == message.id).
+                    addClass("updateReceipt");
+            break;
+          case "updateReceiptStop":
+            $('li').filter(function() $(this).data('id') == message.id).
+                    removeClass("updateReceipt");
+            break;
         }
       },
       false

--- a/addon/data/content/throbber.svg
+++ b/addon/data/content/throbber.svg
@@ -1,0 +1,23 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+	 - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<svg  xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      width="24" height="24" viewBox="0 0 64 64">
+  <g>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(0, 32, 32)" fill="#BBB"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(30, 32, 32)" fill="#AAA"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(60, 32, 32)" fill="#999"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(90, 32, 32)" fill="#888"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(120, 32, 32)" fill="#777"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(150, 32, 32)" fill="#666"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(180, 32, 32)" fill="#555"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(210, 32, 32)" fill="#444"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(240, 32, 32)" fill="#333"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(270, 32, 32)" fill="#222"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(300, 32, 32)" fill="#111"/>
+    <rect x="30" y="4" width="4" height="15" transform="rotate(330, 32, 32)" fill="#000"/>
+    <animateTransform attributeName="transform" type="rotate" calcMode="discrete" values="0 32 32;30 32 32;60 32 32;90 32 32;120 32 32;150 32 32;180 32 32;210 32 32;240 32 32;270 32 32;300 32 32;330 32 32" dur="0.8s" repeatCount="indefinite"/>
+  </g>
+</svg>

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -433,7 +433,11 @@ let simulator = module.exports = {
       app.receiptType = receiptType;
       this._updateApp(appId, this.sendListApps.bind(this));
     } else {
+      app.updateReceipt = true;
+      this.postUpdateReceiptStart(appId);
       this.fetchReceipt(manifestURL, receiptType, function fetched(err, receipt) {
+        delete app.updateReceipt;
+        this.postUpdateReceiptStop(appId);
         if (err || !receipt) {
           console.error(err || "No receipt");
         } else {
@@ -442,6 +446,18 @@ let simulator = module.exports = {
           this._updateApp(appId, this.sendListApps.bind(this));
         }
       }.bind(this));
+    }
+  },
+
+  postUpdateReceiptStart: function(id) {
+    if (this.worker) {
+      this.worker.postMessage({ name: "updateReceiptStart", id: id });
+    }
+  },
+
+  postUpdateReceiptStop: function(id) {
+    if (this.worker) {
+      this.worker.postMessage({ name: "updateReceiptStop", id: id });
     }
   },
 


### PR DESCRIPTION
@potch does this seem reasonable?

I'm not entirely happy with setting _app.updateReceipt_, since the _app_ object comes from SimpleStorage and persists across browser sessions, whereas an "update receipt" request always terminates with the session. But there is no session-specific storage at the moment, so setting a property of the _app_ object is the best thing we can do. And it should be ok, as the callback deletes the property when the request completes (which should happen even if the user terminates the session in the middle of the request).

In addition to setting _app.updateReceipt_, which ensures the throbber will appear if the user reloads the Dashboard while an update request is underway, the changeset messages the Dashboard when the request starts/stops, so it can update the specific app record. I don't think we have code that does this yet; currently we regenerate the entire app list anytime anything changes. But it seems preferable to update the specific record than to regenerate the whole list, especially if regeneration takes non-negligible time, so the list doesn't flash in a distracting way.

Ultimately we'll want a more general solution, but that can wait until another development cycle.
