### PR TITLE
provide valid manifest URL when requesting receipt for app

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -420,14 +420,10 @@ let simulator = module.exports = {
     }
   },
 
-  receiptManifestURL: function receiptManifestURL(appType, appOrigin) {
-    return appType === "local" ? "https://" + appOrigin + ".simulator" : appOrigin;
-  },
-
   updateReceiptType: function updateReceiptType(appId, receiptType) {
     let app = this.apps[appId];
-    let manifestURL = this.receiptManifestURL(app.type,
-                                              app.origin || app.xkey);
+    let manifestURL =
+      app.type === "local" ? "https://" + app.xkey + ".simulator" : app.origin;
     if (receiptType === "none") {
       app.receipt = null;
       app.receiptType = receiptType;


### PR DESCRIPTION
I'm not sure when exactly this regressed, but selecting a receipt type currently fails on all packaged apps:

```
info: r2d2b2g: Simulator.onMessage updateReceiptType
info: r2d2b2g: Fetching refunded test receipt for https://app://aa58c9d7-3bec-844f-9001-43c272eca956.simulator
info: r2d2b2g: Bad request made to test receipt server: {"manifest_url":["Enter a valid URL."]}
error: r2d2b2g: INVALID_RECEIPT
```

Here's a fix. Along the way, I unrefactor a one-line function with only a single call site to make it easier to read and understand what _updateReceiptType_ is doing to construct the manifest URL (we can always refactor again once a second call site appears).

cc: @nickdesaulniers, @ochameau

@potch: does this make sense?
