### PR TITLE
notify user and reset receipt menu on fetch receipt failure

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -435,7 +435,8 @@ let simulator = module.exports = {
         delete app.updateReceipt;
         this.postUpdateReceiptStop(appId);
         if (err || !receipt) {
-          console.error(err || "No receipt");
+          this.error("Error getting receipt: " + (err || "unknown error"));
+          this.sendListApps();
         } else {
           app.receipt = receipt;
           app.receiptType = receiptType;
@@ -467,26 +468,21 @@ let simulator = module.exports = {
         receipt_type: receiptType,
       },
       onComplete: function(response) {
-        const INVALID_MESSAGE = "INVALID_RECEIPT";
         if (response.status === 400 && "error_message" in response.json) {
-          console.log("Bad request made to test receipt server: " +
-            JSON.stringify(response.json.error_message));
-          return cb(INVALID_MESSAGE, null);
+          return cb("bad request made to test receipt server: " +
+                    JSON.stringify(response.json.error_message), null);
         }
         if (response.status !== 201) {
-          console.log("Unexpected status code " + response.status);
-          return cb(INVALID_MESSAGE, null);
+          return cb("unexpected status code " + response.status, null);
         }
         if (!response.json) {
-          console.log("Expected JSON response.");
-          return cb(INVALID_MESSAGE, null);
+          return cb("expected JSON response", null);
         }
         if (!('receipt' in response.json)) {
-          console.log("Expected receipt field in test receipt response");
-          return cb(INVALID_MESSAGE, null);
+          return cb("expected receipt field in test receipt response", null);
         }
         console.log("Received receipt: " + response.json.receipt);
-        cb(null, response.json.receipt);
+        return cb(null, response.json.receipt);
       },
     }).post();
   },


### PR DESCRIPTION
When an "fetch receipt" request fails, the user isn't notified, and the Receipt Type dropdown menu in the Dashboard doesn't change back to the value it originally had, so it looks like the Dashboard successfully fetched a new receipt.

The Dashboard should notify the user that it failed to fetch the receipt, and the dropdown menu should change back to the original receipt type.

cc: @nickdesaulniers

@potch: seem ok?

Note that the change exposes the specific error message, which might be a bit too technical. But I think it's better than giving a vague, generic message; it'll help us debug user issues.

Also note that the change calls _sendListApps_, which regenerates the whole list. That's overkill, but it's the current convention, and since this is an edge case, it doesn't seem worth making another one-off to update just the specific app record. We can address that in the next cycle.

Finally, note that I add a _return_ to the _onComplete_ callback, which is an unrelated change that makes that callback always return a value (otherwise my JavaScript strict syntax checker complains that the function doesn't always do that).
