### PR TITLE
clear indexedDB on "refresh app + clear cache and storages"

### DIFF
--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -123,6 +123,12 @@ function simulatorAppUpdate(clearCacheAndStorages) {
     // clear cookies
     Services.cookies.removeCookiesForApp(localId, false);
 
+    // clear indexedDB
+    // NOTE: extracted from "resource://gre/modules/ForgetAboutSite.jsm"
+    Cc["@mozilla.org/dom/indexeddb/manager;1"].
+    getService(Ci.nsIIndexedDatabaseManager).
+    clearDatabasesForURI(iframe.contentDocument.documentURIObject);
+
     // clear app cache
     try {
       Cc["@mozilla.org/network/application-cache-service;1"].


### PR DESCRIPTION
added a new "clear indexedDB" step to the "refresh + clear" hidden shortcut (fix #666)

NOTE: tested using https://github.com/mozilla/high-fidelity
