### PR TITLE
Allow the simulator to update a single app row.

### DIFF
--- a/addon/data/content/js/applist.js
+++ b/addon/data/content/js/applist.js
@@ -25,23 +25,48 @@ var AppList = (function() {
     var apps = {};
     var appIds = [];
 
-    function update(data) {
+    function updateAll(data) {
+        console.log('updating all apps');
+        if (!data) return;
         apps = data;
         appIds = Object.keys(apps).sort();
         render();
     }
 
-    function render() {
-        listEl.empty();
+    function update(id, data) {
+        console.log('updating', id);
+        var app = apps[id];
+        if (!app) return;
+        if ('key' in app) {
+            // if data is a whole app, replace the record.
+            apps[id] = app;
+        } else {
+            // otherwise, extend the app object.
+            for (key in data) {
+                app[key] = data[key];
+            }
+        }
+        render(id);
+    }
 
-        // $('#new-project').toggle(!appIds.length);
-        //listEl.toggle(!!appIds.length);
-        if (appIds.length) {
-            for (var i=0; i<appIds.length; i++) {
-                renderSingle(appIds[i]);
+    function render(id) {
+        if (id) {
+            // re-render a single app in place.
+            var row = $('[data-id="'+id+'"]');
+            if (row.length) {
+                row.replaceWith(renderSingle(id));
             }
         } else {
-            listEl.append('<li class="notice">No Apps Installed</li>');
+            // re-render all apps.
+            console.log('re-rendering all apps');
+            listEl.empty();
+            if (appIds.length) {
+                for (var i=0; i<appIds.length; i++) {
+                    listEl.append(renderSingle(appIds[i]));
+                }
+            } else {
+                listEl.append('<li class="notice">No Apps Installed</li>');
+            }
         }
     }
 
@@ -92,7 +117,7 @@ var AppList = (function() {
         var appEl = $(appTemplate.render(app).trim());
 
         // FIXME: Make an actual list, add a template engine
-        listEl.append(appEl);
+        return appEl;
     }
 
     listEl.on('change', '.receipt-type', function(e) {
@@ -143,6 +168,7 @@ var AppList = (function() {
 
 
     return {
+        'updateAll': updateAll,
         'update': update,
         'apps': apps
     };

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -85,15 +85,16 @@ var Simulator = {
             }
             break;
           case "listApps":
-            AppList.update(message.list);
+            AppList.updateAll(message.list);
             break;
           case "updateReceiptStart":
-            $('li').filter(function() $(this).data('id') == message.id).
-                    addClass("updateReceipt");
+            AppList.update(message.id, { updateReceipt: true });
             break;
           case "updateReceiptStop":
-            $('li').filter(function() $(this).data('id') == message.id).
-                    removeClass("updateReceipt");
+            AppList.update(message.id, { updateReceipt: false });
+            break;
+          case "updateSingleApp":
+            AppList.update(message.id, message.app);
             break;
         }
       },

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -148,7 +148,7 @@ let simulator = module.exports = {
         // Update the Dashboard to reflect changes to the record and run the app
         // if the update succeeded.  Otherwise, it isn't necessary to notify
         // the user about the error, as it'll show up in the validation results.
-        simulator.sendListApps();
+        simulator.sendSingleApp(manifestFile);
         if (!error) {
           simulator.runApp(app);
         }
@@ -235,11 +235,11 @@ let simulator = module.exports = {
       // validation, but validation can stall and never call our callback;
       // and we want to make sure the app listing is updated with the info
       // we just got from the manifest; so we do it here as well.
-      simulator.sendListApps();
+      simulator.sendSingleApp(id);
 
       simulator.validateApp(id, function(error, app) {
         // update dashboard app validation info
-        simulator.sendListApps();
+        simulator.sendSingleApp(id);
 
         if (!error) {
           // NOTE: try to updateApp if there isn't any blocking error
@@ -263,7 +263,7 @@ let simulator = module.exports = {
 
     if (!config) {
       if (this.worker) {
-        this.sendListApps();
+        this.sendSingleApp(id);
       }
       if (next) {
         next();
@@ -416,7 +416,7 @@ let simulator = module.exports = {
     }
 
     if (this.worker) {
-      this.sendListApps();
+      this.sendSingleApp(id);
     }
   },
 
@@ -427,7 +427,9 @@ let simulator = module.exports = {
     if (receiptType === "none") {
       app.receipt = null;
       app.receiptType = receiptType;
-      this._updateApp(appId, this.sendListApps.bind(this));
+      this._updateApp(appId, function() {
+        this.sendSingleApp(appId);
+      });
     } else {
       app.updateReceipt = true;
       this.postUpdateReceiptStart(appId);
@@ -436,13 +438,22 @@ let simulator = module.exports = {
         this.postUpdateReceiptStop(appId);
         if (err || !receipt) {
           this.error("Error getting receipt: " + (err || "unknown error"));
-          this.sendListApps();
+          this.sendSingleApp(appId);
         } else {
           app.receipt = receipt;
           app.receiptType = receiptType;
-          this._updateApp(appId, this.sendListApps.bind(this));
+          this._updateApp(appId, function() {
+            this.sendSingleApp(appId);
+          });
         }
       }.bind(this));
+    }
+  },
+
+  sendSingleApp: function(id) {
+    let app = this.apps[id];
+    if (this.worker) {
+      this.worker.postMessage({ name: "updateSingleApp", id: id, app: app });
     }
   },
 
@@ -504,13 +515,13 @@ let simulator = module.exports = {
       if (error) {
         simulator.error(error);
         config.removed = false;
-        simulator.sendListApps();
+        simulator.sendSingleApp(id);
         return;
       }
       simulator.remoteSimulator.uninstall(config.xkey, function() {
         // app uninstall completed
         // TODO: add success/error detection and report to the user
-        simulator.sendListApps();
+        simulator.sendSingleApp(id);
       });
     });
   },
@@ -529,7 +540,7 @@ let simulator = module.exports = {
     simulator.updateApp(id, function next(error, app) {
       // app reinstall completed
       // success/error detection and report to the user
-      simulator.sendListApps();
+      simulator.sendSingleApp(id);
       if (error) {
         simulator.error(error);
       } else {
@@ -738,7 +749,7 @@ let simulator = module.exports = {
       // Update the Dashboard to reflect changes to the record and run the app
       // if the update succeeded.  Otherwise, it isn't necessary to notify
       // the user about the error, as it'll show up in the validation results.
-      simulator.sendListApps();
+      simulator.sendSingleApp(id);
       if (!error) {
         simulator.runApp(app);
       }


### PR DESCRIPTION
Sometimes, we don't need to re-render all apps. Actually, most times we don't. I added an `sendSingleApp` method to the simulator, which works with `AppList.update()` to re-render a single row of the dashboard. I also migrated all the `sendListApps` calls that were only updating a single app to use the new method.
