### PR TITLE
Added try/catch when checking for ps in PATH. Fixes #702

### DIFF
--- a/addon/lib/adb.js
+++ b/addon/lib/adb.js
@@ -247,10 +247,14 @@ this.ADB = {
       let paths = env.PATH.split(':');
       let len = paths.length;
       for (let i = 0; i < len; i++) {
-        let fullyQualified = file.join(paths[i], psCommand);
-        if (file.exists(fullyQualified)) {
-          ps = fullyQualified;
-          break;
+        try {
+          let fullyQualified = file.join(paths[i], psCommand);
+          if (file.exists(fullyQualified)) {
+            ps = fullyQualified;
+            break;
+          }
+        } catch (e) {
+          // keep checking PATH if we run into NS_ERROR_FILE_UNRECOGNIZED_PATH
         }
       }
       if (!ps) {


### PR DESCRIPTION
This should save us if there is anything that the `file` module chokes on in `$PATH` (it no longer chokes on a `.` in the `$PATH`).

This doesn't catch every component error, though-- it will just fix this one problem.
