### PR TITLE
Add a page-mod against marketplace to ease reviewer life.

### DIFF
--- a/addon/data/marketplace-script.js
+++ b/addon/data/marketplace-script.js
@@ -1,0 +1,30 @@
+/*
+ * Hack the marketplace reviewer UI to add a "Run in simulator" button
+ * to ease reviewer app testing
+ */
+
+let installButton = document.querySelector("button.product.install");
+if (installButton) {
+  let simulatorButton = installButton.cloneNode();
+  simulatorButton.textContent = "Run in simulator";
+  simulatorButton.style.marginTop = "1em";
+  simulatorButton.removeAttribute("disabled");
+  simulatorButton.classList.remove("disabled");
+  // Remove this class to prevent the button listener click to trigger regular app install
+  simulatorButton.classList.remove("product");
+  installButton.parentNode.insertBefore(simulatorButton,
+                                        installButton.nextSibling);
+  simulatorButton.addEventListener("click", function () {
+    if (installButton.dataset.is_packaged === "true") {
+      self.postMessage({
+        type: "packaged",
+        miniManifestURL: installButton.dataset.manifest_url
+      });
+    } else {
+      self.postMessage({
+        type: "hosted",
+        manifestURL: installButton.dataset.manifest_url
+      });
+    }
+  });
+}

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -19,6 +19,8 @@ const Gcli = require('gcli');
 const Simulator = require("simulator.js");
 const Prefs = require("preferences-service");
 
+require("marketplace-mod");
+
 Cu.import("resource://gre/modules/Services.jsm");
 
 PageMod({

--- a/addon/lib/marketplace-mod.js
+++ b/addon/lib/marketplace-mod.js
@@ -1,0 +1,90 @@
+const { PageMod } = require("sdk/page-mod");
+const Self = require("self");
+const File = require("file");
+const Request = require('./request').Request;
+const simulator = require("./simulator");
+
+const { CC, Cu, Cc, Ci } = require("chrome");
+// use addon manager internal helper to extract a zip to a folder
+const { extractFiles } = Cu.import("resource://gre/modules/XPIProvider.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+const WebBrowserPersist = CC("@mozilla.org/embedding/browser/nsWebBrowserPersist;1",
+                               "nsIWebBrowserPersist");
+
+function downloadFile(url, path, onDone) {  
+  let persist = WebBrowserPersist();
+  persist.persistFlags = persist.PERSIST_FLAGS_REPLACE_EXISTING_FILES;
+  let uri = Services.io.newURI(url, null, null);
+  let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
+  file.initWithPath(path);
+  persist.progressListener = {
+    onStateChange: function(aProgress, aRequest, aStateFlag, aStatus) {
+      if (aStateFlag & Ci.nsIWebProgressListener.STATE_STOP) {
+        onDone();
+      }
+    }
+  };
+  persist.saveURI(uri, null, null, null, null, file, null);
+}
+
+PageMod({
+  include: [
+    "https://marketplace-dev.allizom.org/reviewers/apps/review/*",
+    "https://marketplace-altdev.allizom.org/reviewers/apps/review/*",
+    "https://marketplace.allizom.org/reviewers/apps/review/*",
+    "https://marketplace.firefox.com/reviewers/apps/review/*"
+  ],
+  contentScriptFile: Self.data.url("marketplace-script.js"),
+  onAttach: function (worker) {
+    worker.on("message", function (data) {
+      console.log("message: "+JSON.stringify(data));
+
+      simulator.run(function(error) {
+        if (error) {
+          simulator.error(error);
+          return;
+        }
+        if (data.type == "packaged") {
+          // For packaged app, first download marketplace "mini" manifest
+          // that contains few regular manifest properties and a `package_path`
+          // attribute refering to the absolute URL for the zip package.
+          Request({
+            url: data.miniManifestURL,
+            onComplete: function (response) {
+              let miniManifest = response.json;
+
+              let packageURL = miniManifest.package_path;
+
+              // Now, download the zip
+              let tmpDir = Services.dirsvc.get("TmpD", Ci.nsIFile).path;
+              let id = Math.round(Math.random()*10000);
+
+              let archiveFile = File.join(tmpDir,
+                                          "marketplace-app-" + id + ".zip");
+              downloadFile(packageURL, archiveFile, function () {
+                // Then, extract the zip to a temporary folder
+                let tempWebappDir = File.join(tmpDir, "marketplace-app-" + id);
+                File.mkpath(tempWebappDir);
+
+                let zipFile = Cc["@mozilla.org/file/local;1"]
+                                .createInstance(Ci.nsIFile);
+                zipFile.initWithPath(archiveFile);
+                let targetDir = Cc["@mozilla.org/file/local;1"]
+                                  .createInstance(Ci.nsIFile);
+                targetDir.initWithPath(tempWebappDir);
+
+                extractFiles(zipFile, targetDir);
+
+                // Finally, register this temporary folder to the simulator
+                let manifestPath = File.join(tempWebappDir, "manifest.webapp");
+                simulator.addManifestFile(manifestPath);
+              });
+            }
+          }).get();
+        } else {
+          simulator.addManifestUrl(data.manifestURL);
+        }
+      });
+    });
+  }
+});

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -131,28 +131,32 @@ let simulator = module.exports = {
     let ret = fp.show();
     if (ret == Ci.nsIFilePicker.returnOK || ret == Ci.nsIFilePicker.returnReplace) {
       let manifestFile = fp.file.path;
-      console.log("Selected " + manifestFile);
-
-      let apps = simulator.apps;
-      let xkey = UUID.uuid().toString().slice(1, -1);
-      apps[manifestFile] = {
-        type: "local",
-        xkey: xkey,
-        origin: "app://" + xkey
-      };
-      console.log("Registered App " + JSON.stringify(apps[manifestFile]));
-
-      let next = function next(error, app) {
-        // Update the Dashboard to reflect changes to the record and run the app
-        // if the update succeeded.  Otherwise, it isn't necessary to notify
-        // the user about the error, as it'll show up in the validation results.
-        simulator.sendSingleApp(manifestFile);
-        if (!error) {
-          simulator.runApp(app);
-        }
-      };
-      this.updateApp(manifestFile, next);
+      simulator.addManifestFile(manifestFile);
     }
+  },
+
+  addManifestFile: function (manifestFile) {
+    console.log("Selected " + manifestFile);
+
+    let apps = simulator.apps;
+    let xkey = UUID.uuid().toString().slice(1, -1);
+    apps[manifestFile] = {
+      type: "local",
+      xkey: xkey,
+      origin: "app://" + xkey
+    };
+    console.log("Registered App " + JSON.stringify(apps[manifestFile]));
+
+    let next = function next(error, app) {
+      // Update the Dashboard to reflect changes to the record and run the app
+      // if the update succeeded.  Otherwise, it isn't necessary to notify
+      // the user about the error, as it'll show up in the validation results.
+      simulator.sendSingleApp(manifestFile);
+      if (!error) {
+        simulator.runApp(app);
+      }
+    };
+    this.updateApp(manifestFile, next);
   },
 
   updateAll: function(oncompleted) {


### PR DESCRIPTION
Thanks @diox, who registered me some test account on marketplace dev server and introduced me to the reviewer UI!

That page-mod adds a button in reviewer UI, to easily register an hosted or packaged app, meant to be reviewed, in the Simulator. I choosed to register the app to the dashboard, as it is simplier to implement that way, but may be we want to bypass the dashboard and only push the app to b2g? I can easily see a reviewer dashboard made of tons of apps being reviewed, whereas he don't really want them to be registered...

@myk What do you think about a page-mod? Do you think this code is meant to be hosted in the simulator or should we make another addon that depends on it? Or do something completely different? Is marketplace the only one website where we would like to integrate with the simulator?
