### PR TITLE
Changed condition variable API so that XP would work

### DIFF
--- a/addon/lib/adb/adb-io-thread-spawner.js
+++ b/addon/lib/adb/adb-io-thread-spawner.js
@@ -47,9 +47,11 @@ worker.once("init", function({ libPath, driversPath, threadName, t_ptrS, platfor
     const io_bridge_funcs = [
       { "AdbReadEndpointAsync": AdbReadEndpointAsyncType },
       { "AdbWriteEndpointAsync": AdbWriteEndpointAsyncType },
+      { "AdbHasOvelappedIoComplated": AdbHasOvelappedIoComplatedType },
       { "AdbReadEndpointSync": AdbReadEndpointSyncType },
       { "AdbWriteEndpointSync": AdbWriteEndpointSyncType },
       { "AdbCloseHandle": AdbCloseHandleType },
+      { "AdbGetOvelappedIoResult": AdbGetOvelappedIoResultType }
     ];
 
     let bb = new BridgeBuilder(I, libadbdrivers);

--- a/addon/lib/adb/adb-types.js
+++ b/addon/lib/adb/adb-types.js
@@ -43,7 +43,7 @@
   const LPOVERLAPPED = ctypes.void_t.ptr;
 
   const AdbReadEndpointAsyncType =
-    ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ ctypes.void_t.ptr, ctypes.uint64_t, ctypes.uint64_t.ptr, ctypes.uint64_t, HANDLE ]);
+    ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ ADBAPIHANDLE, ctypes.void_t.ptr, ctypes.uint64_t, ctypes.uint64_t.ptr, ctypes.uint64_t, HANDLE ]);
   const AdbWriteEndpointAsyncType =
     ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ ADBAPIHANDLE, ctypes.void_t.ptr, ctypes.uint64_t, ctypes.uint64_t.ptr, ctypes.uint64_t, HANDLE ]);
   const AdbReadEndpointSyncType =

--- a/android-tools/adb-bin/adb.h
+++ b/android-tools/adb-bin/adb.h
@@ -52,7 +52,7 @@ typedef void * ADBAPIHANDLE;
 //    from native code (wtf windows) so make printf log to a file    
 extern FILE* LOG_FILE;
 #undef printf
-#define printf(...) do { fprintf(LOG_FILE, __VA_ARGS__); fflush(LOG_FILE); } while (0); 
+#define printf(...) do { SYSTEMTIME st; GetSystemTime(&st); fprintf(LOG_FILE, "%d::%d::", st.wSecond, st.wMilliseconds); fprintf(LOG_FILE, __VA_ARGS__); fflush(LOG_FILE); } while (0); 
 #endif
 
 #define MAX_PAYLOAD 4096
@@ -306,11 +306,13 @@ struct func_carrier {
 
 #ifdef WIN32
 struct dll_io_bridge {
-  ADBAPIHANDLE (*AdbReadEndpointAsync)(void *, unsigned long, unsigned long *, unsigned long, HANDLE);
+  ADBAPIHANDLE (*AdbReadEndpointAsync)(ADBAPIHANDLE, void *, unsigned long, unsigned long *, unsigned long, HANDLE);
   ADBAPIHANDLE (*AdbWriteEndpointAsync)(ADBAPIHANDLE, void *, unsigned long, unsigned long *, unsigned long, HANDLE);
+  bool (*AdbHasOvelappedIoComplated)(ADBAPIHANDLE adb_io_completion);
   bool (*AdbReadEndpointSync)(ADBAPIHANDLE, void *, unsigned long, unsigned long *, unsigned long);
   bool (*AdbWriteEndpointSync)(ADBAPIHANDLE, void *, unsigned long, unsigned long *, unsigned long);
   bool (*AdbCloseHandle)(ADBAPIHANDLE);
+  bool (*AdbGetOvelappedIoResult)(ADBAPIHANDLE, LPOVERLAPPED, unsigned long*, bool);
 };
 
 struct dll_bridge {

--- a/android-tools/adb-bin/mutex_list.h
+++ b/android-tools/adb-bin/mutex_list.h
@@ -16,8 +16,6 @@ ADB_MUTEX(local_transports_lock)
 //#endif
 ADB_MUTEX(usb_lock)
 ADB_MUTEX(should_kill_lock)
-ADB_MUTEX(should_kill_cond_lock)
-ADB_MUTEX(die_fdevent_lock)
 
 // Sadly logging to /data/adb/adb-... is not thread safe.
 //  After modifying adb.h::D() to count invocations:

--- a/android-tools/adb-bin/sysdeps.h
+++ b/android-tools/adb-bin/sysdeps.h
@@ -46,13 +46,15 @@
 #define __inline__ __inline
 
 typedef CRITICAL_SECTION          adb_mutex_t;
-typedef CONDITION_VARIABLE        adb_cond_t;
+typedef HANDLE                    adb_cond_t;
 
 #define  ADB_MUTEX_DEFINE(x)     adb_mutex_t   x
 
 /* declare all mutexes */
 /* For win32, adb_sysdeps_init() will do the mutex runtime initialization. */
 #define  ADB_MUTEX(x)   extern adb_mutex_t  x;
+#define  ADB_COND_DEFINE(x)    adb_cond_t x;
+#define  ADB_COND(x) x = CreateEvent(0, 0, 0, 0);
 #include "mutex_list.h"
 
 void _cleanup_winsock();
@@ -71,12 +73,13 @@ static __inline__ void  adb_mutex_unlock( adb_mutex_t*  lock )
 
 static __inline__ void adb_cond_wait( adb_cond_t * condition, adb_mutex_t * mutex )
 {
-    SleepConditionVariableCS(condition, mutex, INFINITE);
+    // We can't use SleepConditionVariableCS because it only works on Vista+
+    WaitForSingleObject(condition, INFINITE);
 }
 
 static __inline__ void adb_cond_broadcast( adb_cond_t * condition )
 {
-    WakeAllConditionVariable(condition);
+    SetEvent(condition);
 }
 
 typedef struct { unsigned  tid; }  adb_thread_t;

--- a/android-tools/adb-bin/sysdeps_win32.cpp
+++ b/android-tools/adb-bin/sysdeps_win32.cpp
@@ -1960,15 +1960,13 @@ void fdevent_js_die_setup(int js_die_fd) {
     printf("Added FDE");
 }
 
-ADB_MUTEX_DEFINE( die_fdevent_lock );
-adb_cond_t die_fdevent_cond;
+ADB_COND_DEFINE(die_fdevent_cond);
 
 void should_die_fdevent_() {
-    adb_mutex_lock( &die_fdevent_lock );
+    ADB_COND(die_fdevent_cond);
     while (SHOULD_DIE != 2) {
-        adb_cond_wait( &die_fdevent_cond, &die_fdevent_lock );
+        adb_cond_wait( &die_fdevent_cond, NULL );
     }
-    adb_mutex_unlock( &die_fdevent_lock );
 }
 
 void fdevent_loop(int exit_fd)

--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -394,11 +394,10 @@ int usb_write(usb_handle* handle, const void* data, int len) {
 
 extern THREAD_LOCAL int (*getLastError)();
 int usb_read(usb_handle *handle, void* data, int len) {
-  unsigned long time_out = 10;
   unsigned long read = 0;
   int ret;
   char * data_ = (char *)data;
-  ADBAPIHANDLE complated_handle = NULL;
+  ADBAPIHANDLE completed_handle = NULL;
 
   D("usb_read %d\n", len);
   if (NULL != handle) {
@@ -408,23 +407,23 @@ int usb_read(usb_handle *handle, void* data, int len) {
       // loop until there is a byte
       int saved_errno = 0;
       
-        D("Pre read call\n");
-        complated_handle = o_bridge->AdbReadEndpointAsync(handle->adb_read_pipe,
-                                    (void*)data_,
-                                    (unsigned long)xfer,
-                                    &read,
-                                    0,
-                                    NULL);
-        saved_errno = getLastError();
-        if (complated_handle == NULL) {
-          D("AdbReadEndpointAsync, errno: %d\n", saved_errno);
-          return -1;
-        }
-        D("Read async started");
+      D("Pre read call\n");
+      completed_handle = o_bridge->AdbReadEndpointAsync(handle->adb_read_pipe,
+                                  (void*)data_,
+                                  (unsigned long)xfer,
+                                  &read,
+                                  0,
+                                  NULL);
+      saved_errno = getLastError();
+      if (completed_handle == NULL) {
+        D("AdbReadEndpointAsync, errno: %d\n", saved_errno);
+        return -1;
+      }
+      D("Read async started");
 
-      int hasComplated = FALSE;
+      int hasCompleted = FALSE;
       do {
-        hasComplated = o_bridge->AdbHasOvelappedIoComplated(complated_handle);
+        hasCompleted = o_bridge->AdbHasOvelappedIoComplated(completed_handle);
         saved_errno = getLastError();
         if (saved_errno != 0) {
           D("HasOvelappedIoComplated, errno: %d\n", saved_errno);
@@ -438,11 +437,11 @@ int usb_read(usb_handle *handle, void* data, int len) {
         }
 
         Sleep(100);
-      } while(!hasComplated);
+      } while(!hasCompleted);
       D("Post hasComplated\n");
 
 
-      ret = o_bridge->AdbGetOvelappedIoResult(complated_handle, NULL, &read, true);
+      ret = o_bridge->AdbGetOvelappedIoResult(completed_handle, NULL, &read, true);
       if (!ret) {
         D("AdbGetOvelappedIoResult(read %u) failure (%u). Error %u, read %u\n",
             xfer, ret, getLastError(), read);


### PR DESCRIPTION
The condition variable shim used Windows APIs that were only supported by Vista+. This patch rewrites the condition variable shim using APIs that are also supported on XP.

In order to fix a bug with using the Windows Event APIs, reading from USB is now done using the `AdbReadEndpointAsync` function.
