### PR TITLE
Created js-message bridge between C and JS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ adb:
 	if [ "$(LIBADB_LOCATION)" = "local" ]; then \
 	  make -C android-tools lib; \
 	  cp $(ADB_OUT_DIR)libadb$(LIB_SUFFIX) addon/data/$(B2G_PLATFORM)/adb; \
+	  cp $(ADB_OUT_DIR)libtest$(LIB_SUFFIX) addon/data/$(B2G_PLATFORM)/adb; \
 	fi;
 
 locales:

--- a/addon/lib/adb/adb-server-thread.js
+++ b/addon/lib/adb/adb-server-thread.js
@@ -10,11 +10,16 @@ const INSTANTIATOR_URL = URL_PREFIX + "ctypes-instantiator.js";
 const EVENTED_CHROME_WORKER_URL = URL_PREFIX + "evented-chrome-worker.js";
 const CONSOLE_URL = URL_PREFIX + "worker-console.js";
 const ADB_TYPES = URL_PREFIX + "adb-types.js";
+const JS_MESSAGE = URL_PREFIX + "js-message.js";
 
 const WORKER_URL_IO_THREAD_SPAWNER = URL_PREFIX + "adb-io-thread-spawner.js";
 const WORKER_URL_DEVICE_POLL = URL_PREFIX + "adb-device-poll-thread.js";
 
-importScripts(INSTANTIATOR_URL, EVENTED_CHROME_WORKER_URL, CONSOLE_URL, ADB_TYPES);
+importScripts(INSTANTIATOR_URL,
+              EVENTED_CHROME_WORKER_URL,
+              CONSOLE_URL,
+              ADB_TYPES,
+              JS_MESSAGE);
 
 const worker = new EventedChromeWorker(null);
 const console = new Console(worker);
@@ -24,6 +29,16 @@ let libadb = null;
 let libPath_;
 let restartMeFn = function restart_me() {
   worker.emitAndForget("restart-me", { });
+};
+let w;
+let jsMsgFn = function js_msg(channel, args) {
+  switch (channel.readString()) {
+    default:
+      console.log("Unknown message");
+  }
+
+  w = ctypes.uintptr_t(10);
+  return ctypes.cast(w, ctypes.uintptr_t.ptr);
 };
 
 worker.once("init", function({ libPath }) {
@@ -58,7 +73,14 @@ worker.once("init", function({ libPath }) {
                   args: [ CallbackType.ptr ]
                 }, libadb);
 
+  let install_js_msg =
+      I.declare({ name: "install_js_msg",
+                  returns: ctypes.void_t,
+                  args: [ JsMsgType.ptr ]
+                }, libadb);
+
   install_thread_locals(CallbackType.ptr(restartMeFn));
+  install_js_msg(JsMsgType.ptr(jsMsgFn));
 });
 
 worker.once("start", function({ port, log_path }) {

--- a/addon/lib/adb/adb-types.js
+++ b/addon/lib/adb/adb-types.js
@@ -16,6 +16,8 @@
 
   const NULL = ctypes.cast(ctypes.uint64_t(0x0), ctypes.void_t.ptr);
   const CallbackType = ctypes.FunctionType(ctypes.default_abi, ctypes.void_t, []);
+  // js-ctypes doesn't support variadic callback functions so this will have to do
+  const JsMsgType = ctypes.FunctionType(ctypes.default_abi, ctypes.void_t.ptr, [ ctypes.char.ptr, ctypes.void_t.ptr ]);
   const IntCallableType = ctypes.FunctionType(ctypes.default_abi, ctypes.int, []);
   const AdbOpenAccessType = ctypes.int;
   const AdbOpenSharingMode = ctypes.int;
@@ -114,6 +116,7 @@
   module.exports = {
     NULL: NULL,
     CallbackType: CallbackType,
+    JsMsgType: JsMsgType,
     IntCallableType: IntCallableType,
     AdbOpenAccessType: AdbOpenAccessType,
     AdbOpenSharingMode: AdbOpenSharingMode,

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -12,6 +12,7 @@
   require("adb/adb-io-thread-spawner.js");
   require("adb/ctypes-bridge-builder.js");
   require("adb/worker-console.js");
+  require("adb/js-message.js");
  */
 
 const { Cc, Ci, Cr, Cu, ChromeWorker } = require("chrome");

--- a/addon/lib/adb/js-message.js
+++ b/addon/lib/adb/js-message.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * JsMessage
+ *
+ * Takes a (void *)(struct *) from C and unpacks it properly
+ */
+
+'use strict';
+
+;(function(exports, module) {
+
+  if (module) {
+    const { Cu } = require("chrome");
+    Cu.import("resource://gre/modules/ctypes.jsm");
+  }
+
+  // the lifetime of the value returned from the JsMessage if it is allocated in
+  //   JS lasts until MSG is called again (this will prevent leaks as much as
+  //   possible)
+  let w;
+  exports.JsMessage = {
+    pack: function pack(val, type) {
+      if (type(0) === Number(0)) {
+        w = ctypes.intptr_t(val);
+        return ctypes.cast(w, ctypes.intptr_t.ptr);
+      } else if (type(0) === String(0)) {
+        w = ctypes.char.array()(val);
+        return w;
+      } else {
+        w = ctypes.intptr_t(-404);
+        return ctypes.cast(w, ctypes.intptr_t.ptr);
+      }
+    },
+
+    unpack: function unpack(struct_ptr /*, types */) {
+      let types = Array.slice(arguments, 1);
+      let struct_body = types.map(function (type, i) {
+        let o = {};
+        o["s_" + i] = type;
+        return o;
+      });
+
+      const struct_type =
+        new ctypes.StructType("anon", struct_body);
+
+      let as_struct_type = ctypes.cast(struct_ptr, struct_type.ptr);
+      return types.map(function(unused, i) as_struct_type.contents["s_" + i]);
+    }
+  };
+
+}).apply(null,
+  typeof module !== 'undefined' ?
+       [exports, module] : [this]);
+

--- a/addon/test/test-js-message.js
+++ b/addon/test/test-js-message.js
@@ -1,0 +1,120 @@
+const { Cu } = require("chrome");
+Cu.import("resource://gre/modules/ctypes.jsm");
+
+const File = require("file");
+const { platform } = require("system");
+const URL = require("url");
+const self = require("self");
+
+const { Instantiator } = require("adb/ctypes-instantiator");
+const { JsMsgType } =
+    require("adb/adb-types");
+const { JsMessage } = require("adb/js-message");
+
+let extension = (platform === "winnt") ? ".dll" : ".so";
+const I = new Instantiator();
+
+let platformDir;
+if (platform === "winnt") {
+  platformDir = "win32";
+} else if (platform === "linux") {
+  let is64bit = (require("runtime").XPCOMABI.indexOf("x86_64") == 0);
+  if (is64bit) {
+    platformDir = "linux64";
+  } else {
+    platformDir = "linux";
+  }
+} else if (platform === "darwin") {
+  platformDir = "mac64";
+} else {
+  throw "Unsupported platform";
+}
+let libPath = URL.toFilename(self.data.url(platformDir + "/adb/libtest" + extension));
+
+let hasLib;
+let libtest;
+
+let jsMsgFn = function js_msg(channel, args) {
+  switch (channel.readString()) {
+    case "test1":
+      let [x, y] = JsMessage.unpack(args, ctypes.int, ctypes.int);
+      return JsMessage.pack((x*10) + y, Number);
+    case "test2":
+      let [a, b, c] = JsMessage.unpack(args, ctypes.int, ctypes.char.ptr, ctypes.int);
+      return JsMessage.pack(a.toString() + b.readString() + c.toString(), String);
+    default:
+      return JsMessage.pack(-1, Number);
+  }
+};
+
+exports["test a if libtest exists"] = function(assert, done) {
+  hasLib = File.exists(libPath);
+
+  assert.pass(hasLib ? "Native test lib exists. Running tests." 
+                     : "Native test lib doesn't exist. Skipping tests");
+  done();
+};
+
+exports["test b init"] = function(assert, done) {
+  if (!hasLib) {
+    assert.pass("Skipping");
+    done();
+    return;
+  }
+
+  libtest = ctypes.open(libPath);
+  let install_js_msg =
+      I.declare({ name: "install_js_msg",
+                  returns: ctypes.void_t,
+                  args: [ JsMsgType.ptr ]
+                }, libtest);
+
+  install_js_msg(JsMsgType.ptr(jsMsgFn));
+
+  I.declare({ name: "call_test1",
+              returns: ctypes.int,
+              args: []
+            }, libtest);
+
+  I.declare({ name: "call_test2",
+              returns: ctypes.char.ptr,
+              args: []
+            }, libtest);
+
+  I.declare({ name: "call_garbage",
+              returns: ctypes.int,
+              args: []
+            }, libtest);
+
+  assert.pass("Initialized libtest");
+  done();
+};
+
+exports["test c call native code"] = function(assert, done) {
+  if (!hasLib) {
+    assert.pass("Skipping");
+    done();
+    return;
+  }
+  let res = I.use("call_test1")();
+  assert.equal(res, 273, "test1 called into JS and returned a value to C");
+  res = I.use("call_test2")();
+  assert.equal(res.readString(), "11hello72", "test2 called into JS and returned a value to C");
+  res = I.use("call_garbage")();
+  assert.equal(res, -1, "garbage called into JS and fell to default case and returned a value to C");
+  done();
+};
+
+exports["test zz after"] = function(assert, done) {
+  if (!hasLib) {
+    assert.pass("Skipping");
+    done();
+    return;
+  }
+  libtest.close();
+  assert.pass("Closed libtest");
+  done();
+};
+
+require("test").run(exports);
+

--- a/android-tools/adb-bin/Makefile
+++ b/android-tools/adb-bin/Makefile
@@ -94,17 +94,29 @@ endif
 OBJS= $(CSRCS:.c=.o) $(CPPSRCS:.cpp=.o)
 SRCS= $(CSRCS) $(CPPSRCS)
 
+TESTSRCS= test-js-message.c
+TESTOBJS= $(TESTSRCS:.c=.o)
+
 all: $(ADB_TARGETS)
 
 adb: $(OBJS)
 	$(CC) -o adb$(EXE) $(LDFLAGS) $(OBJS) $(LIBS)
 
 clean:
-	rm -rf $(OBJS) adb$(EXE) libadb$(DLL)
+	rm -rf $(OBJS) $(TESTOBJS) adb$(EXE) libadb$(DLL) libtest$(DLL)
 
-nixlib: $(OBJS)
+nixlib: nixlibadb nixlibtest
+
+nixlibadb: $(OBJS)
 	$(CC) -shared -o libadb$(DLL) $(LDFLAGS) $(OBJS) $(LIBS)
 
-winlib:
+nixlibtest: $(TESTOBJS)
+	$(CC) test-js-message.c -shared -fPIC -o libtest$(DLL)
+
+winlib: winlibadb winlibtest
+
+winlibadb:
 	echo make-win.bat | cmd $(VS_DEVELOPER_CMD_PATH)
 
+winlibtest: $(TESTOBJS)
+	echo "cl.exe test-js-message.c /link /DLL /OUT:..\\win-out\\libtest.dll" | cmd $(VS_DEVELOPER_CMD_PATH)

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -55,6 +55,7 @@ FILE* LOG_FILE;
 
 THREAD_LOCAL void (*restart_me)();
 THREAD_LOCAL int (*getLastError)();
+THREAD_LOCAL void * (*js_msg)(char *, void *);
 int HOST = 0;
 int gListenAll = 0;
 
@@ -176,6 +177,10 @@ void cleanup_all() {
 
 void install_thread_locals_(void (*restart_me_)()) {
   restart_me = restart_me_;
+}
+
+void install_js_msg_(void *(js_msg_)(char *, void *)) {
+  js_msg = js_msg_;
 }
 
 void install_getLastError_(int (*getLastError_)()) {
@@ -1637,7 +1642,6 @@ int main(int argc, char **argv)
     // return adb_commandline(argc - 1, argv + 1);
     return 0;
 }
-
 
 //#undef D
 //#define D D_

--- a/android-tools/adb-bin/adb.h
+++ b/android-tools/adb-bin/adb.h
@@ -303,6 +303,7 @@ struct func_carrier {
 };
 
 #include "array_lists.h"
+#include "js_message.h"
 
 #ifdef WIN32
 struct dll_io_bridge {
@@ -351,6 +352,7 @@ struct dll_io_bridge { };
 #endif
 void array_lists_init_();
 void install_thread_locals_(void (*restart_me_)());
+void install_js_msg_(void * (*js_msg_)(char *, void *));
 void install_getLastError_(int (*getLastError)());
 int adb_thread_create( adb_thread_t  *thread, adb_thread_func_t  start, void*  arg, char * tag );
 void dump_thread_tag();

--- a/android-tools/adb-bin/exports.cpp
+++ b/android-tools/adb-bin/exports.cpp
@@ -20,6 +20,7 @@ DLL_EXPORT int connect_service(const char * service);
 DLL_EXPORT int read_fd(int fd, char * buffer, int size);
 
 DLL_EXPORT void install_thread_locals(void (*restart_me)());
+DLL_EXPORT void install_js_msg(void *(js_msg)(char *, void *));
 DLL_EXPORT void array_lists_init();
 
 DLL_EXPORT int main_server(struct adb_main_input * input_args);
@@ -34,6 +35,10 @@ DLL_EXPORT void on_kill_io_pump(atransport * t, bool (*close_handle_func)(ADBAPI
 
   DLL_EXPORT void install_thread_locals(void (*restart_me)()) {
     install_thread_locals_(restart_me);
+  }
+
+  DLL_EXPORT void install_js_msg(void *(js_msg)(char *, void *)) {
+    install_js_msg_(js_msg);
   }
 
   DLL_EXPORT void install_getLastError(int (*getLastError)()) {

--- a/android-tools/adb-bin/js_message.h
+++ b/android-tools/adb-bin/js_message.h
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef JS_MESSAGE_H
+#define JS_MESSAGE_H
+
+#define MSG(save, channel, instance) do {\
+    *save = js_msg(channel, (void *)&instance);\
+  } while(0)
+
+#endif
+

--- a/android-tools/adb-bin/test-js-message.c
+++ b/android-tools/adb-bin/test-js-message.c
@@ -1,0 +1,56 @@
+#include "js_message.h"
+
+#ifdef __cplusplus
+  #define EXTERN_C extern "C"
+#else
+  #define EXTERN_C
+#endif
+
+#ifdef _WIN32
+#include <Windows.h>
+#define DLL_EXPORT EXTERN_C _declspec(dllexport)
+#define THREAD_LOCAL _declspec(thread)
+#else
+#define THREAD_LOCAL __thread
+#define DLL_EXPORT
+#endif
+
+THREAD_LOCAL void * (*js_msg)(char *, void *);
+
+DLL_EXPORT void install_js_msg(void * (*js_msg_)(char *, void *)) {
+  js_msg = js_msg_;
+}
+
+DLL_EXPORT int call_test1() {
+  void * res;
+  struct test1_msg {
+    int x;
+    int y;
+  };
+  struct test1_msg m = { 27, 3 };
+  MSG(&res, "test1", m);
+  return (int)res;
+}
+
+DLL_EXPORT char * call_test2() {
+  void * res;
+  struct test2_msg {
+    int a;
+    char * b;
+    int c;
+  };
+  struct test2_msg m = { 11, "hello", 72 };
+  MSG(&res, "test2", m);
+  return (char *)res;
+}
+
+DLL_EXPORT int call_garbage() {
+  void * res;
+  struct garbage_msg {
+    char * s;
+  };
+  struct garbage_msg g = { "_" };
+  MSG(&res, "s", g);
+  return (int)res;
+}
+


### PR DESCRIPTION
This changeset adds a generic communication bridge from C to JS.

Why make a communication bridge?
Each time we need to add a C to JS communication we have to create a new function pointer, initialize it properly in JS (which means declaring the types for the function pointer), modify or create a new function in the native code that takes the function pointer as a parameter, and then assign the function pointer to some variable that is accessible in the scope that it will be called.
This bridge makes it so that we reuse the same function call to JS and we can switch on a channel name and extract arbitrary data out of the arguments.

This shouldn't actually be merged-- it's just an example of this function being called during ADB initialization. @mykmelez suggested that I create a pull-request just for this bridge before using it everywhere.

C communicates to JS with `MSG("channel", [type1, value1, ...])`
JS uses `JsMessage.prototype.unravel(type1, [type2, ...])` to extract data.

See https://github.com/bkase/r2d2b2g/compare/js-message?expand=1#L4R185 for an example of `MSG`
The `MSG` macro creates an anonymous structure for the given types and populates it with the proper values before passing it as a parameter to the generic `void * js_msg(void *)` function.
The macro is complex but it makes it really easy to pass a struct to JS without having to construct a struct manually in C. If JS gets an actual struct, we can use `ctypes.cast` and not have to worry about pointer offsets and sizes of the types passed in. `MSG` is implemented in _js-message.h_.

See https://github.com/bkase/r2d2b2g/compare/js-message?expand=1#L0R35 for an example of `JsMessage`'s `unravel`. This method takes the types of each of the elements (which we know based on the channel name) and returns an N-tuple of the data extracted from an anonymous struct constructed from the type information. `JsMessage` is implemented in _adb/js-message.js_

If this lands, I can clean up the old native code in a few places as well (since we can share one function pointer now).

@ochameau Can you look at this?
