### PR TITLE
 Device tracker calls callback instead of sockets

### DIFF
--- a/addon/lib/adb/adb-device-tracker.js
+++ b/addon/lib/adb/adb-device-tracker.js
@@ -21,98 +21,69 @@ function debug() {
   console.debug.apply(console, ["ADB: "].concat(Array.prototype.slice.call(arguments, 0)));
 }
 
-let waitForFirst = true;
 let devices = { };
-let socket;
 let hasDevice = false;
+let listenId = null;
+let worker = null;
 module.exports = {
   get hasDevice() {
     return hasDevice;
   },
 
-  reset: function reset() {
-    waitForFirst = false;
-    devices = { };
-    socket.close();
-    hasDevice = false;
+  start: function(worker_) {
+    worker = worker_;
+    debug("Starting deviceTracker");
+    listenId = worker.listenAndForget("device-update", (function onDeviceUpdate({ msg }) {
+      debug("Got device update: " + msg);
+      this.handleChange(msg);
+    }).bind(this));
   },
 
-  start: function track_start() {
-    socket = client.connect();
-    Services.obs.notifyObservers(null, "adb-track-devices-start", null);
-
-    socket.s.onopen = function() {
-      debug("trackDevices onopen");
-      // Services.obs.notifyObservers(null, "adb-track-devices-start", null);
-      let req = client.createRequest("host:track-devices");
-      socket.send(req);
-    };
-
-    socket.s.onerror = function(event) {
-      debug("trackDevices onerror: " + event.data);
-      Services.obs.notifyObservers(null, "adb-track-devices-stop", null);
-    };
-
-    socket.s.onclose = function() {
-      debug("trackDevices onclose");
-      Services.obs.notifyObservers(null, "adb-track-devices-stop", null);
-    };
-
-    socket.s.ondata = function(aEvent) {
-      debug("trackDevices ondata");
-      let data = aEvent.data;
-      debug("length=" + data.byteLength);
-      let dec = new TextDecoder();
-      debug(dec.decode(new Uint8Array(data)).trim());
-
-      // check the OKAY or FAIL on first packet.
-      if (waitForFirst) {
-        if (!client.checkResponse(data)) {
-          socket.close();
+  handleChange: function handleChange(msg) {
+    if (msg == "") {
+      hasDevice = false;
+      // All devices got disconnected.
+      for (let dev in devices) {
+        devices[dev] = false;
+        Services.obs.notifyObservers(null, "adb-device-disconnected", dev);
+      }
+    } else {
+      hasDevice = true;
+      // One line per device, each line being $DEVICE\t(offline|device)
+      let lines = msg.split("\n");
+      let newDev = {};
+      lines.forEach(function(aLine) {
+        if (aLine.length == 0) {
           return;
         }
-      }
 
-      let packet = client.unpackPacket(data, !waitForFirst);
-      waitForFirst = false;
-
-      if (packet.data == "") {
-        hasDevice = false;
-        // All devices got disconnected.
-        for (let dev in devices) {
-          devices[dev] = false;
-          Services.obs.notifyObservers(null, "adb-device-disconnected", dev);
-        }
-      } else {
-        hasDevice = true;
-        // One line per device, each line being $DEVICE\t(offline|device)
-        let lines = packet.data.split("\n");
-        let newDev = {};
-        lines.forEach(function(aLine) {
-          if (aLine.length == 0) {
-            return;
+        let [dev, status] = aLine.split("\t");
+        newDev[dev] = status !== "offline";
+      });
+      // Check which device changed state.
+      for (let dev in newDev) {
+        if (devices[dev] != newDev[dev]) {
+          if (dev in devices || newDev[dev]) {
+            let topic = newDev[dev] ? "adb-device-connected"
+                                    : "adb-device-disconnected";
+            Services.obs.notifyObservers(null, topic, dev);
           }
-
-          let [dev, status] = aLine.split("\t");
-          newDev[dev] = status !== "offline";
-        });
-        // Check which device changed state.
-        for (let dev in newDev) {
-          if (devices[dev] != newDev[dev]) {
-            if (dev in devices || newDev[dev]) {
-              let topic = newDev[dev] ? "adb-device-connected"
-                                      : "adb-device-disconnected";
-              Services.obs.notifyObservers(null, topic, dev);
-            }
-            devices[dev] = newDev[dev];
-          }
+          devices[dev] = newDev[dev];
         }
       }
-    };
+    }
   },
 
-  stop: function track_stop() {
-    socket.close();
+  stop: function stop() {
+    if (listenId !== null) {
+      worker.freeListener("device-update", listenId);
+    }
+  },
+
+  reset: function reset() {
+    devices = { };
+    hasDevice = false;
+    listenId = null;
   }
 }
 

--- a/addon/lib/adb/adb-device-tracker.js
+++ b/addon/lib/adb/adb-device-tracker.js
@@ -81,6 +81,7 @@ module.exports = {
   },
 
   reset: function reset() {
+    worker = null;
     devices = { };
     hasDevice = false;
     listenId = null;

--- a/addon/lib/adb/adb-server-thread.js
+++ b/addon/lib/adb/adb-server-thread.js
@@ -30,19 +30,17 @@ let libPath_;
 let restartMeFn = function restart_me() {
   worker.emitAndForget("restart-me", { });
 };
-let w;
+
 let jsMsgFn = function js_msg(channel, args) {
   switch (channel.readString()) {
     case "device-update":
-      let [updates] = new JsMessage(args).unravel(ctypes.char.ptr);
+      let [updates] = JsMessage.unpack(args, ctypes.char.ptr);
       worker.emitAndForget("device-update", { msg: updates.readString() });
-      break;
+      return JsMessage.pack(10, Number);
     default:
       console.debug("Unknown message");
+      return JsMessage.pack(-1, Number);
   }
-
-  w = ctypes.uintptr_t(10);
-  return ctypes.cast(w, ctypes.uintptr_t.ptr);
 };
 
 worker.once("init", function({ libPath }) {

--- a/addon/lib/adb/adb-server-thread.js
+++ b/addon/lib/adb/adb-server-thread.js
@@ -33,8 +33,12 @@ let restartMeFn = function restart_me() {
 let w;
 let jsMsgFn = function js_msg(channel, args) {
   switch (channel.readString()) {
+    case "device-update":
+      let [updates] = new JsMessage(args).unravel(ctypes.char.ptr);
+      worker.emitAndForget("device-update", { msg: updates.readString() });
+      break;
     default:
-      console.log("Unknown message");
+      console.debug("Unknown message");
   }
 
   w = ctypes.uintptr_t(10);

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -264,6 +264,8 @@ exports._startAdbInBackground = function startAdbInBackground() {
   ioWorker = new EventedChromeWorker(WORKER_URL_IO, "io_thread", context);
   utilWorker = new EventedChromeWorker(WORKER_URL_UTIL, "util_thread", context);
 
+  deviceTracker.start(serverWorker);
+
   serverWorker.emit("init", { libPath: libPath }, function initack() {
     serverWorker.emit("start", { port: 5037, log_path: File.join(TmpD, "adb.log") }, function started(res) {
       console.debug("adb server thread returned: " + res.result);
@@ -272,9 +274,6 @@ exports._startAdbInBackground = function startAdbInBackground() {
 
   serverWorker.onceAndForget("kill-server-fd", function({ fd }) {
     server_die_fd = fd;
-  });
-  serverWorker.onceAndForget("track-ready", function trackack() {
-    deviceTracker.start();
   });
 
   [ioWorker, utilWorker].forEach(function initworker(w) {

--- a/android-tools/adb-bin/adb.h
+++ b/android-tools/adb-bin/adb.h
@@ -304,6 +304,7 @@ struct func_carrier {
 
 #include "array_lists.h"
 #include "js_message.h"
+extern THREAD_LOCAL void * (*js_msg)(char *, void *);
 
 #ifdef WIN32
 struct dll_io_bridge {
@@ -395,8 +396,6 @@ int adb_main(int is_daemon, int server_port, int is_lib_call);
 void init_transport_registration(int (*spawnIO)(atransport*));
 int  list_transports(char *buf, size_t  bufsize, int long_listing);
 void update_transports(void);
-
-asocket*  create_device_tracker(void);
 
 /* Obtain a transport from the available transports.
 ** If state is != CS_ANY, only transports in that state are considered.

--- a/android-tools/adb-bin/services.cpp
+++ b/android-tools/adb-bin/services.cpp
@@ -342,7 +342,8 @@ static void wait_for_state(int fd, void* cookie)
 asocket*  host_service_to_socket(const char*  name, const char *serial)
 {
     if (!strcmp(name,"track-devices")) {
-        return create_device_tracker();
+        printf("the track-devices service is disabled. Listen for the \"device-update\" channel\n");
+        return NULL;
     } else if (!strncmp(name, "wait-for-", strlen("wait-for-"))) {
         struct state_info* sinfo = (struct state_info *)malloc(sizeof(struct state_info));
 


### PR DESCRIPTION
This pull request rips out the device tracker implementation (based on socket communication) in native code and replaces it with one that calls JS callback (sends a js-message) every time some device state changes.
