### PR TITLE
ADB in make test

### DIFF
--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -1374,7 +1374,7 @@ let simulator = module.exports = {
     console.log("simulator.observe: " + topic);
     switch (topic) {
       case "adb-ready":
-        ADB.trackDevices();
+        ADB && ADB.trackDevices();
         break;
       case "adb-device-connected":
         deviceConnected = true;


### PR DESCRIPTION
- [x] Tests pass on Mac and Linux if ADB is already open in a background process
- [ ] Better error message if libadb is open in different Firefox profile
- [ ] Fix crash on Windows with test-receipts (waiting on #757, hopefully it's related)

Unfortunately, most of my tests rely on `ADB.shell` which the fallback ADB module does not support so those tests are skipped for the first fix.
