### PR TITLE
Better error message if ADB is already running

### DIFF
--- a/addon/lib/adb/adb-running-checker.js
+++ b/addon/lib/adb/adb-running-checker.js
@@ -40,7 +40,7 @@ exports.check = function check() {
         let { length, data } = client.unpackPacket(aData);
         debug("length: ", length, "data: ", data);
         socket.close();
-        deferred.resolve(true);
+        deferred.resolve(data.indexOf("001f") != -1);
         break;
       default:
         debug("Unexpected State: " + state);

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -268,7 +268,10 @@ exports._startAdbInBackground = function startAdbInBackground() {
 
   serverWorker.emit("init", { libPath: libPath }, function initack() {
     serverWorker.emit("start", { port: 5037, log_path: File.join(TmpD, "adb.log") }, function started(res) {
-      console.debug("adb server thread returned: " + res.result);
+      console.debug("adb server thread returned: " + res.ret);
+      if (res.ret == -1) {
+        Services.obs.notifyObservers(null, "adb-port-in-use", null);
+      }
     });
   });
 

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -1192,7 +1192,7 @@ void build_local_name(char* target_str, size_t target_size, int server_port)
   snprintf(target_str, target_size, "tcp:%d", server_port);
 }
 
-void * server_thread(void * args) {
+int server_thread(void * args) {
   adb_sysdeps_init();
 
   struct adb_main_input* input = (struct adb_main_input*)args;
@@ -1247,8 +1247,7 @@ void * server_thread(void * args) {
     build_local_name(local_name, sizeof(local_name), server_port);
     if(install_listener(local_name, "*smartsocket*", NULL, 0)) {
         D("Error installing listener\n");
-        return NULL;
-
+        return -1;
     }
 
     if (is_daemon)
@@ -1481,11 +1480,8 @@ int handle_host_request(char *service, transport_type ttype, char* serial, int r
   //
     // returns our value for ADB_SERVER_VERSION
     if (!strcmp(service, "version")) {
-        char version[12];
-        snprintf(version, sizeof version, "%04x", ADB_SERVER_VERSION);
-        snprintf(buf, sizeof buf, "OKAY%04x%s", (unsigned)strlen(version), version);
-        writex(reply_fd, buf, strlen(buf));
-        return 0;
+        printf("the version service is disabled.\n");
+        return -1;
     }
 
     if(!strncmp(service,"get-serialno",strlen("get-serialno"))) {

--- a/android-tools/adb-bin/exports.cpp
+++ b/android-tools/adb-bin/exports.cpp
@@ -116,8 +116,7 @@ DLL_EXPORT void on_kill_io_pump(atransport * t, bool (*close_handle_func)(ADBAPI
   // NOTE: input_args is free'd with `free` so must be alloc'd with malloc.
   //       This call loops forever.
   DLL_EXPORT int main_server(struct adb_main_input * input_args) {
-    server_thread((void *)input_args);
-    return 0;
+    return server_thread((void *)input_args);
   }
 
 #ifdef __APPLE__

--- a/android-tools/adb-bin/threads.h
+++ b/android-tools/adb-bin/threads.h
@@ -3,7 +3,7 @@
 
 #include "adb.h"
 
-void * server_thread(void * args);
+int server_thread(void * args);
 #ifdef __APPLE__
 void * RunLoopThread(void * unused);
 #else


### PR DESCRIPTION
Simple change to give a better message if you try to run `make test` if another Simulator has started up ADB. See #760
