### PR TITLE
Refactor old C->JS code to use new JsMessages

### DIFF
--- a/addon/lib/adb/adb-server-thread.js
+++ b/addon/lib/adb/adb-server-thread.js
@@ -11,6 +11,7 @@ const EVENTED_CHROME_WORKER_URL = URL_PREFIX + "evented-chrome-worker.js";
 const CONSOLE_URL = URL_PREFIX + "worker-console.js";
 const ADB_TYPES = URL_PREFIX + "adb-types.js";
 const JS_MESSAGE = URL_PREFIX + "js-message.js";
+const COMMON_MESSAGE_HANDLER = URL_PREFIX + "common-message-handler.js";
 
 const WORKER_URL_IO_THREAD_SPAWNER = URL_PREFIX + "adb-io-thread-spawner.js";
 const WORKER_URL_DEVICE_POLL = URL_PREFIX + "adb-device-poll-thread.js";
@@ -19,7 +20,8 @@ importScripts(INSTANTIATOR_URL,
               EVENTED_CHROME_WORKER_URL,
               CONSOLE_URL,
               ADB_TYPES,
-              JS_MESSAGE);
+              JS_MESSAGE,
+              COMMON_MESSAGE_HANDLER);
 
 const worker = new EventedChromeWorker(null);
 const console = new Console(worker);
@@ -27,21 +29,55 @@ const console = new Console(worker);
 let I = null;
 let libadb = null;
 let libPath_;
-let restartMeFn = function restart_me() {
-  worker.emitAndForget("restart-me", { });
-};
 
-let jsMsgFn = function js_msg(channel, args) {
-  switch (channel.readString()) {
+let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
+  switch(channel) {
     case "device-update":
       let [updates] = JsMessage.unpack(args, ctypes.char.ptr);
       worker.emitAndForget("device-update", { msg: updates.readString() });
-      return JsMessage.pack(10, Number);
+      return JsMessage.pack(0, Number);
+    case "spawn-io-threads":
+      let [ t_ptr ] = JsMessage.unpack(args, ctypes.void_t.ptr);
+      console.debug("spawnIO was called from C, with voidPtr: " + t_ptr.toString());
+      let t_ptrS = packPtr(t_ptr);
+      worker.runOnPeerThread(function spawnIO_task(t_ptrS, workerURI) {
+        let inputThread = this.newWorker(workerURI, "input_thread");
+        inputThread.emitAndForget("init",
+          { libPath: context.libPath,
+            threadName: "device_input_thread",
+            t_ptrS: t_ptrS,
+            platform: context.platform,
+            driversPath: context.driversPath
+          });
+
+        let outputThread = this.newWorker(workerURI, "output_thread");
+        outputThread.emitAndForget("init",
+          { libPath: context.libPath,
+            threadName: "device_output_thread",
+            t_ptrS: t_ptrS,
+            platform: context.platform,
+            driversPath: context.driversPath
+          });
+
+        this.context.outputThread = outputThread;
+        this.context.t_ptrS = t_ptrS;
+
+      }, t_ptrS, WORKER_URL_IO_THREAD_SPAWNER);
+      return JsMessage.pack(0, Number);
+    case "spawn-device-loop":
+      console.debug("spawnD called from C");
+      worker.runOnPeerThread(function spawnD_task(workerURI) {
+        let devicePollWorker = this.newWorker(workerURI, "device_poll_thread");
+        devicePollWorker.emitAndForget("init", { libPath: context.libPath,
+                                                 driversPath: context.driversPath,
+                                                 platform: context.platform });
+      }, WORKER_URL_DEVICE_POLL);
+      return JsMessage.pack(0, Number);
     default:
-      console.debug("Unknown message");
+      console.log("Unknown message: " + channel);
       return JsMessage.pack(-1, Number);
   }
-};
+});
 
 worker.once("init", function({ libPath }) {
   libPath_ = libPath;
@@ -69,19 +105,12 @@ worker.once("init", function({ libPath }) {
               args: [ ctypes.ArrayType(ctypes.int, 2) ]
             }, libadb);
 
-  let install_thread_locals =
-      I.declare({ name: "install_thread_locals",
-                  returns: ctypes.void_t,
-                  args: [ CallbackType.ptr ]
-                }, libadb);
-
   let install_js_msg =
       I.declare({ name: "install_js_msg",
                   returns: ctypes.void_t,
                   args: [ JsMsgType.ptr ]
                 }, libadb);
 
-  install_thread_locals(CallbackType.ptr(restartMeFn));
   install_js_msg(JsMsgType.ptr(jsMsgFn));
 });
 
@@ -93,7 +122,8 @@ worker.once("start", function({ port, log_path }) {
   let contents = {
     is_daemon: 0,
     server_port: port,
-    is_lib_call: 1
+    is_lib_call: 1,
+    log_path: ctypes.char.array()(log_path)
   };
 
   let onTrackReadyfn = function onTrackReady() {
@@ -103,51 +133,6 @@ worker.once("start", function({ port, log_path }) {
 
   contents.on_track_ready =
     ctypes.FunctionType(ctypes.default_abi, ctypes.void_t, []).ptr(onTrackReadyfn);
-
-  let spawnIOfn = function spawnIO(t_ptr) {
-    console.debug("spawnIO was called from C, with voidPtr: " + t_ptr.toString());
-    let t_ptrS = packPtr(t_ptr);
-    worker.runOnPeerThread(function spawnIO_task(t_ptrS, workerURI) {
-      let inputThread = this.newWorker(workerURI, "input_thread");
-      inputThread.emitAndForget("init",
-        { libPath: context.libPath,
-          threadName: "device_input_thread",
-          t_ptrS: t_ptrS,
-          platform: context.platform,
-          driversPath: context.driversPath
-        });
-
-      let outputThread = this.newWorker(workerURI, "output_thread");
-      outputThread.emitAndForget("init",
-        { libPath: context.libPath,
-          threadName: "device_output_thread",
-          t_ptrS: t_ptrS,
-          platform: context.platform,
-          driversPath: context.driversPath
-        });
-
-      this.context.outputThread = outputThread;
-      this.context.t_ptrS = t_ptrS;
-
-    }, t_ptrS, WORKER_URL_IO_THREAD_SPAWNER);
-  };
-
-  contents.spawnIO = ctypes.FunctionType(ctypes.default_abi, ctypes.int, [atransport.ptr]).ptr(spawnIOfn);
-
-
-  // NOTE: on linux this will not be called
-  let spawnDfn = function() {
-    console.debug("spawnD called from C");
-    worker.runOnPeerThread(function spawnD_task(workerURI) {
-      let devicePollWorker = this.newWorker(workerURI, "device_poll_thread");
-      devicePollWorker.emitAndForget("init", { libPath: context.libPath, driversPath: context.driversPath, platform: context.platform });
-
-    }, WORKER_URL_DEVICE_POLL);
-  };
-
-  contents.spawnD = ctypes.FunctionType(ctypes.default_abi, ctypes.int).ptr(spawnDfn);
-
-  contents.log_path = ctypes.char.array()(log_path);
 
   let pipe = ctypes.ArrayType(ctypes.int, 2)();
   I.use("socket_pipe")(pipe);

--- a/addon/lib/adb/adb-types.js
+++ b/addon/lib/adb/adb-types.js
@@ -107,9 +107,6 @@
 
       { on_track_ready: ctypes.FunctionType(ctypes.default_abi, ctypes.void_t, []).ptr },
 
-      { spawnIO: ctypes.FunctionType(ctypes.default_abi, ctypes.int, [ atransport.ptr ]).ptr },
-      { spawnD: ctypes.FunctionType(ctypes.default_abi, ctypes.int).ptr },
-
       { log_path: ctypes.char.ptr }
     ]);
 

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -13,6 +13,7 @@
   require("adb/ctypes-bridge-builder.js");
   require("adb/worker-console.js");
   require("adb/js-message.js");
+  require("adb/common-message-handler.js");
  */
 
 const { Cc, Ci, Cr, Cu, ChromeWorker } = require("chrome");

--- a/addon/lib/adb/common-message-handler.js
+++ b/addon/lib/adb/common-message-handler.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Common message handler
+ *
+ * Registers common listeners before passing control
+ * to regular JsMessage handlers
+ */
+
+'use strict';
+
+;(function(exports, module) {
+
+  let isModule = !!module;
+  if (isModule) {
+    const { Cu } = require("chrome");
+    Cu.import("resource://gre/modules/ctypes.jsm");
+    const { JsMessage } = require("adb/js-message");
+  } else {
+    module = {};
+  }
+
+  module.exports = function CommonMessageHandler(worker, console, andThen) {
+    return function(channel, args) {
+      try {
+        channel = channel.readString();
+        switch(channel) {
+          case "restart-adb":
+            worker.emitAndForget("restart-me", { });
+            return JsMessage.pack(1, Number);
+          default:
+            return andThen(channel, args);
+        }
+      } catch (e) {
+        console.log("JS exception: " + e);
+        return JsMessage.pack(-1, Number);
+      }
+    };
+  };
+
+  if (!isModule) {
+    exports.CommonMessageHandler = module.exports;
+  }
+
+}).apply(null,
+  typeof module !== 'undefined' ?
+       [exports, module] : [this]);
+

--- a/android-tools/adb-bin/adb.h
+++ b/android-tools/adb-bin/adb.h
@@ -282,9 +282,6 @@ struct adb_main_input {
 
   void (*on_track_ready)();
 
-  int (*spawnIO)(atransport*);
-  int (*spawnD)();
-
   // this is a string pointing to a valid path for the adb.log
   // because windows won't printf to stdout
   char * log_path;
@@ -352,9 +349,7 @@ struct dll_io_bridge { };
   void should_kill_device_loop();
 #endif
 void array_lists_init_();
-void install_thread_locals_(void (*restart_me_)());
 void install_js_msg_(void * (*js_msg_)(char *, void *));
-void install_getLastError_(int (*getLastError)());
 int adb_thread_create( adb_thread_t  *thread, adb_thread_func_t  start, void*  arg, char * tag );
 void dump_thread_tag();
 int get_guid();
@@ -393,7 +388,7 @@ int adb_main(int is_daemon, int server_port, int is_lib_call);
 /* transports are ref-counted
 ** get_device_transport does an acquire on your behalf before returning
 */
-void init_transport_registration(int (*spawnIO)(atransport*));
+void init_transport_registration();
 int  list_transports(char *buf, size_t  bufsize, int long_listing);
 void update_transports(void);
 
@@ -537,7 +532,7 @@ int  local_connect(int  port);
 int  local_connect_arbitrary_ports(int console_port, int adb_port);
 
 /* usb host/client interface */
-void usb_init(int(*spawnD)());
+void usb_init();
 void usb_cleanup();
 int usb_write(usb_handle *h, const void *data, int len);
 int usb_read(usb_handle *h, void *data, int len);

--- a/android-tools/adb-bin/exports.cpp
+++ b/android-tools/adb-bin/exports.cpp
@@ -19,7 +19,6 @@ DLL_EXPORT void * malloc_(int size);
 DLL_EXPORT int connect_service(const char * service);
 DLL_EXPORT int read_fd(int fd, char * buffer, int size);
 
-DLL_EXPORT void install_thread_locals(void (*restart_me)());
 DLL_EXPORT void install_js_msg(void *(js_msg)(char *, void *));
 DLL_EXPORT void array_lists_init();
 
@@ -33,16 +32,8 @@ void DLL_EXPORT kill_device_loop();
 DLL_EXPORT int usb_monitor(struct dll_bridge * bridge);
 DLL_EXPORT void on_kill_io_pump(atransport * t, bool (*close_handle_func)(ADBAPIHANDLE));
 
-  DLL_EXPORT void install_thread_locals(void (*restart_me)()) {
-    install_thread_locals_(restart_me);
-  }
-
   DLL_EXPORT void install_js_msg(void *(js_msg)(char *, void *)) {
     install_js_msg_(js_msg);
-  }
-
-  DLL_EXPORT void install_getLastError(int (*getLastError)()) {
-    install_getLastError_(getLastError);
   }
 
   DLL_EXPORT void array_lists_init() {

--- a/android-tools/adb-bin/fdevent.cpp
+++ b/android-tools/adb-bin/fdevent.cpp
@@ -113,7 +113,7 @@ static int fd_table_max = 0;
 
 static int epoll_fd = -1;
 
-extern THREAD_LOCAL void (*restart_me)();
+extern THREAD_LOCAL void * (*js_msg)(char *, void *);
 static void fdevent_init()
 {
         /* XXX: what's a good size for the passed in hint? */
@@ -121,7 +121,7 @@ static void fdevent_init()
 
     if(epoll_fd < 0) {
         perror("epoll_create() failed");
-        restart_me();
+        MSG("restart-adb", NULL);
         return;
     }
 
@@ -186,13 +186,13 @@ static void fdevent_update(fdevent *fde, unsigned events)
         if(ev.events) {
             if(epoll_ctl(epoll_fd, EPOLL_CTL_MOD, fde->fd, &ev)) {
                 perror("epoll_ctl() failed\n");
-                restart_me();
+                MSG("restart-adb", NULL);
                 return;
             }
         } else {
             if(epoll_ctl(epoll_fd, EPOLL_CTL_DEL, fde->fd, &ev)) {
                 perror("epoll_ctl() failed\n");
-                restart_me();
+                MSG("restart-adb", NULL);
                 return;
             }
         }
@@ -203,7 +203,7 @@ static void fdevent_update(fdevent *fde, unsigned events)
         if(ev.events) {
             if(epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fde->fd, &ev)) {
                 perror("epoll_ctl() failed\n");
-                restart_me();
+                MSG("restart-adb", NULL);
                 return;
             }
         }
@@ -221,7 +221,7 @@ static void fdevent_process()
     if(n < 0) {
         if(errno == EINTR) return;
         perror("epoll_wait");
-        restart_me();
+        MSG("restart-adb", NULL);
         return;
     }
 

--- a/android-tools/adb-bin/js_message.h
+++ b/android-tools/adb-bin/js_message.h
@@ -5,9 +5,7 @@
 #ifndef JS_MESSAGE_H
 #define JS_MESSAGE_H
 
-#define MSG(save, channel, instance) do {\
-    *save = js_msg(channel, (void *)&instance);\
-  } while(0)
+#define MSG(channel, instance_ptr) js_msg(channel, (void *)instance_ptr)
 
 #endif
 

--- a/android-tools/adb-bin/sockets.c
+++ b/android-tools/adb-bin/sockets.c
@@ -32,7 +32,7 @@ ADB_MUTEX_DEFINE( socket_list_lock );
 
 static void local_socket_close_locked(asocket *s);
 
-extern THREAD_LOCAL void (*restart_me)();
+extern THREAD_LOCAL void * (*js_msg)(char *, void *);
 int sendfailmsg(int fd, const char *reason)
 {
     char buf[9];
@@ -222,7 +222,7 @@ static void local_socket_destroy(asocket  *s)
 
     if (exit_on_close) {
         D("local_socket_destroy: exiting\n");
-        restart_me();
+        MSG("restart-adb", NULL);
         return;
     }
 }

--- a/android-tools/adb-bin/sysdeps_win32.cpp
+++ b/android-tools/adb-bin/sysdeps_win32.cpp
@@ -7,7 +7,7 @@
 #include "adb.h"
 
 
-extern THREAD_LOCAL void (*restart_me)();
+extern THREAD_LOCAL void * (*js_msg)(char *, void *);
 extern void fatal(const char *fmt, ...);
 
 #define assert(cond)  do { if (!(cond)) fatal( "assertion failed '%s' on %s:%ld\n", #cond, __FILE__, __LINE__ ); } while (0)
@@ -2084,7 +2084,7 @@ static int _event_socket_start( EventHook  hook )
             D( "_event_socket_start: WSAEventSelect() for %s failed, error %d\n", hook->fh->name, WSAGetLastError() );
             CloseHandle( hook->h );
             hook->h = INVALID_HANDLE_VALUE;
-            restart_me();
+            MSG("restart-adb", NULL);
             return 0;
         }
         fh->mask = flags;

--- a/android-tools/adb-bin/test-js-message.c
+++ b/android-tools/adb-bin/test-js-message.c
@@ -28,7 +28,7 @@ DLL_EXPORT int call_test1() {
     int y;
   };
   struct test1_msg m = { 27, 3 };
-  MSG(&res, "test1", m);
+  res = MSG("test1", &m);
   return (int)res;
 }
 
@@ -40,7 +40,7 @@ DLL_EXPORT char * call_test2() {
     int c;
   };
   struct test2_msg m = { 11, "hello", 72 };
-  MSG(&res, "test2", m);
+  res = MSG("test2", &m);
   return (char *)res;
 }
 
@@ -50,7 +50,7 @@ DLL_EXPORT int call_garbage() {
     char * s;
   };
   struct garbage_msg g = { "_" };
-  MSG(&res, "s", g);
+  res = MSG("s", &g);
   return (int)res;
 }
 

--- a/android-tools/adb-bin/usb_linux.c
+++ b/android-tools/adb-bin/usb_linux.c
@@ -698,7 +698,7 @@ static void sigalrm_handler(int signo)
     // don't need to do anything here
 }
 
-void usb_init(int (*spawnD)())
+void usb_init()
 {
     // spawnD();
     adb_thread_t * tid = malloc(sizeof(adb_thread_t));

--- a/android-tools/adb-bin/usb_osx.cpp
+++ b/android-tools/adb-bin/usb_osx.cpp
@@ -49,6 +49,7 @@ static CFRunLoopRef currentRunLoop = 0;
 static pthread_mutex_t start_lock;
 static pthread_cond_t start_cond;
 
+extern THREAD_LOCAL void * (*js_msg)(char *, void *);
 ADB_MUTEX_DEFINE( should_kill_lock );
 
 static void AndroidInterfaceAdded(void *refCon, io_iterator_t iterator);
@@ -440,7 +441,7 @@ void* RunLoopThread(void* args)
 
 
 static int initialized = 0;
-void usb_init(int (*spawnD)())
+void usb_init()
 {
     if (!initialized)
     {
@@ -451,7 +452,7 @@ void usb_init(int (*spawnD)())
         adb_cond_init(&start_cond, NULL);
 
         D("Before thread_create");
-        if(spawnD())
+        if((int)MSG("spawn-device-loop", NULL))
             fatal_errno("cannot create RunLoopThread");
         D("After thread_create");
 


### PR DESCRIPTION
Started big code refactor for moving all communication from C to JS to the new JsMessage.
See tasks
- [x] Send message responsible for restarting ADB
- [x] Send getLastError message (needed for Windows driver calls)
- [x] Send thread spawning messages

I made a minor change to MSG. Now it just returns the `void *` (that way it's easy to ignore). I still think it should be a macro just so we can avoid having to cast the argument to a `void *`.

Also made CommonMessageHandler so we don't have to copy paste handlers for messages common to all threads (which right now is ADB restarting).
