### PR TITLE
Improve Windows performance immensely

### DIFF
--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -446,6 +446,7 @@ int usb_read(usb_handle *handle, void* data, int len) {
           // the input thread will notify_should_kill
         }
 
+        Sleep(1);
       } while(!hasCompleted);
       D("Post hasComplated\n");
 

--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -446,7 +446,6 @@ int usb_read(usb_handle *handle, void* data, int len) {
           // the input thread will notify_should_kill
         }
 
-        Sleep(100);
       } while(!hasCompleted);
       D("Post hasComplated\n");
 


### PR DESCRIPTION
Busy-waiting for async reads (assuming system has 2 cores) improves the
performance due to numerous acks in ADB's protocol. Before we were waiting
100ms before every ack! (and there are a ton of acks)

If we need better performance on systems with one core, we should change
this to Sleep(1) to prevent resource starvation (the writer thread goes super slowly) but even 1ms sleeping slows down `adb push` considerably.
