### PR TITLE
Geeksphone Peak on Windows Fix

### DIFF
--- a/addon/lib/adb/adb-device-poll-thread.js
+++ b/addon/lib/adb/adb-device-poll-thread.js
@@ -30,11 +30,15 @@ const console = new Console(worker);
 
 const I = new Instantiator;
 let libadb = null;
+let winusbPath_ = null;
 let getLastError = function() { return 0; };
 let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     case "get-last-error":
       return JsMessage.pack(getLastError(), Number);
+    case "winusbdll-path":
+      console.log("Got request for winusbdll-path");
+      return JsMessage.pack(winusbPath_, String);
     default:
       console.log("Unknown message: " + channel);
   }
@@ -42,8 +46,9 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   return JsMessage.pack(-1, Number);
 });
 
-worker.once("init", function({ libPath, driversPath, platform }) {
+worker.once("init", function({ winusbPath, libPath, driversPath, platform }) {
   libadb = ctypes.open(libPath);
+  winusbPath_ = winusbPath;
 
   let install_js_msg =
       I.declare({ name: "install_js_msg",

--- a/addon/lib/adb/adb-device-poll-thread.js
+++ b/addon/lib/adb/adb-device-poll-thread.js
@@ -30,9 +30,11 @@ const console = new Console(worker);
 
 const I = new Instantiator;
 let libadb = null;
-<<<<<<< HEAD
+let getLastError = function() { return 0; };
 let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
+    case "get-last-error":
+      return JsMessage.pack(getLastError(), Number);
     default:
       console.log("Unknown message: " + channel);
   }
@@ -40,13 +42,6 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   return JsMessage.pack(-1, Number);
 });
 
-
-=======
-let restartMeFn = function restart_me() {
-  worker.emitAndForget("restart-me", { });
-};
-let getLastError;
->>>>>>> AdbWinUsbApi.dll never loaded correctly
 worker.once("init", function({ libPath, driversPath, platform }) {
   libadb = ctypes.open(libPath);
 
@@ -103,14 +98,8 @@ worker.once("init", function({ libPath, driversPath, platform }) {
                 returns: ctypes.int,
                 args: [ struct_dll_bridge.ptr ]
               }, libadb);
-              
-    let install_getLastError =
-        I.declare({ name: "install_getLastError",
-                    returns: ctypes.void_t,
-                    args: [ IntCallableType.ptr ]
-                  }, libadb);
+
     getLastError = bb.getLastError.bind(bb);
-    install_getLastError(IntCallableType.ptr(getLastError));
 
     I.use("usb_monitor")(bridge.address());
     libadbdrivers.close();

--- a/addon/lib/adb/adb-device-poll-thread.js
+++ b/addon/lib/adb/adb-device-poll-thread.js
@@ -30,6 +30,7 @@ const console = new Console(worker);
 
 const I = new Instantiator;
 let libadb = null;
+<<<<<<< HEAD
 let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
   switch(channel) {
     default:
@@ -40,6 +41,12 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
 });
 
 
+=======
+let restartMeFn = function restart_me() {
+  worker.emitAndForget("restart-me", { });
+};
+let getLastError;
+>>>>>>> AdbWinUsbApi.dll never loaded correctly
 worker.once("init", function({ libPath, driversPath, platform }) {
   libadb = ctypes.open(libPath);
 
@@ -89,12 +96,21 @@ worker.once("init", function({ libPath, driversPath, platform }) {
         { "AdbNextInterface": AdbNextInterfaceType }
       ];
 
-    let [struct_dll_bridge, bridge, ref] = new BridgeBuilder(I, libadbdrivers).build("dll_bridge", bridge_funcs);
+    let bb = new BridgeBuilder(I, libadbdrivers);
+    let [struct_dll_bridge, bridge, ref] = bb.build("dll_bridge", bridge_funcs);
 
     I.declare({ name: "usb_monitor",
                 returns: ctypes.int,
                 args: [ struct_dll_bridge.ptr ]
               }, libadb);
+              
+    let install_getLastError =
+        I.declare({ name: "install_getLastError",
+                    returns: ctypes.void_t,
+                    args: [ IntCallableType.ptr ]
+                  }, libadb);
+    getLastError = bb.getLastError.bind(bb);
+    install_getLastError(IntCallableType.ptr(getLastError));
 
     I.use("usb_monitor")(bridge.address());
     libadbdrivers.close();

--- a/addon/lib/adb/adb-server-thread.js
+++ b/addon/lib/adb/adb-server-thread.js
@@ -70,7 +70,8 @@ let jsMsgFn = CommonMessageHandler(worker, console, function(channel, args) {
         let devicePollWorker = this.newWorker(workerURI, "device_poll_thread");
         devicePollWorker.emitAndForget("init", { libPath: context.libPath,
                                                  driversPath: context.driversPath,
-                                                 platform: context.platform });
+                                                 platform: context.platform,
+                                                 winusbPath: context.winusbPath });
       }, WORKER_URL_DEVICE_POLL);
       return JsMessage.pack(0, Number);
     default:

--- a/addon/lib/adb/adb-types.js
+++ b/addon/lib/adb/adb-types.js
@@ -56,7 +56,7 @@
   const AdbEnumInterfacesType =
     ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ GUID, bool, bool, bool ]);
   const AdbCreateInterfaceByNameType = 
-    ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ wchar_t.ptr ]);
+    ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ wchar_t.ptr, wchar_t.ptr ]);
   const AdbCreateInterfaceType = 
     ctypes.FunctionType(ctypes.default_abi, ADBAPIHANDLE, [ GUID, ctypes.uint16_t, ctypes.uint16_t, ctypes.uint8_t ]);
   const AdbGetInterfaceNameType =

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -63,14 +63,16 @@ if (platform === "winnt") {
   throw "Unsupported platform";
 }
 let libPath = URL.toFilename(self.data.url(platformDir + "/adb/libadb" + extension));
-let driversPath = (platform === "winnt") ?
-  URL.toFilename(self.data.url("win32/adb/AdbWinApi.dll")) : null;
+let [driversPath, winusbPath] = (platform === "winnt") ?
+  [URL.toFilename(self.data.url("win32/adb/AdbWinApi.dll")),
+   URL.toFilename(self.data.url("win32/adb/AdbWinUsbApi.dll"))] : [null, null];
 
 // the context is used as shared state between EventedChromeWorker runOnPeerThread calls and this module
 let context = { __workers: [], // this array is populated automatically by EventedChromeWorker
                 platform: platform,
                 driversPath: driversPath,
-                libPath: libPath
+                libPath: libPath,
+                winusbPath: winusbPath
               };
 
 const DEVICE_NOT_CONNECTED = "Device not connected";

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -45,6 +45,8 @@ let serverWorker, ioWorker, utilWorker;
 
 let extension = (platform === "winnt") ? ".dll" : ".so";
 
+require("sdk/preferences/service").set("extensions.sdk.console.logLevel", "debug");
+
 let platformDir;
 if (platform === "winnt") {
   platformDir = "win32";
@@ -268,7 +270,7 @@ exports._startAdbInBackground = function startAdbInBackground() {
   deviceTracker.start(serverWorker);
 
   serverWorker.emit("init", { libPath: libPath }, function initack() {
-    serverWorker.emit("start", { port: 5037, log_path: File.join(TmpD, "adb.log") }, function started(res) {
+    serverWorker.emit("start", { port: 5037, log_path: "C:\\Users\\bkase\\Documents\\work\\r2d2b2g\\adb.log" /* File.join(TmpD, "adb.log") */ }, function started(res) {
       console.debug("adb server thread returned: " + res.result);
     });
   });

--- a/addon/lib/adb/adb.js
+++ b/addon/lib/adb/adb.js
@@ -45,8 +45,6 @@ let serverWorker, ioWorker, utilWorker;
 
 let extension = (platform === "winnt") ? ".dll" : ".so";
 
-require("sdk/preferences/service").set("extensions.sdk.console.logLevel", "debug");
-
 let platformDir;
 if (platform === "winnt") {
   platformDir = "win32";
@@ -272,7 +270,7 @@ exports._startAdbInBackground = function startAdbInBackground() {
   deviceTracker.start(serverWorker);
 
   serverWorker.emit("init", { libPath: libPath }, function initack() {
-    serverWorker.emit("start", { port: 5037, log_path: "C:\\Users\\bkase\\Documents\\work\\r2d2b2g\\adb.log" /* File.join(TmpD, "adb.log") */ }, function started(res) {
+    serverWorker.emit("start", { port: 5037, log_path: File.join(TmpD, "adb.log") }, function started(res) {
       console.debug("adb server thread returned: " + res.result);
     });
   });

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -49,9 +49,9 @@ FILE* debugLog;
 FILE* LOG_FILE;
 #endif
 
-//#define D_ D
-//#undef D
-//#define D printf
+#define D_ D
+#undef D
+#define D printf
 
 THREAD_LOCAL void * (*js_msg)(char *, void *);
 int HOST = 0;
@@ -1630,5 +1630,5 @@ int main(int argc, char **argv)
     return 0;
 }
 
-//#undef D
-//#define D D_
+#undef D
+#define D D_

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -643,6 +643,7 @@ void handle_packet(apacket *p, atransport *t)
 
     case A_CLSE: /* CLOSE(local-id, remote-id, "") */
         if (t->online) {
+            D("CLOSE(%d, %d, \"\")\n", p->msg.arg0, p->msg.arg1);
             if((s = find_local_socket(p->msg.arg1))) {
                 s->close(s);
             }

--- a/android-tools/adb-bin/adb.cpp
+++ b/android-tools/adb-bin/adb.cpp
@@ -49,9 +49,9 @@ FILE* debugLog;
 FILE* LOG_FILE;
 #endif
 
-#define D_ D
-#undef D
-#define D printf
+//#define D_ D
+//#undef D
+//#define D printf
 
 THREAD_LOCAL void * (*js_msg)(char *, void *);
 int HOST = 0;
@@ -1631,5 +1631,5 @@ int main(int argc, char **argv)
     return 0;
 }
 
-#undef D
-#define D D_
+//#undef D
+//#define D D_

--- a/android-tools/adb-bin/adb.h
+++ b/android-tools/adb-bin/adb.h
@@ -316,7 +316,7 @@ struct dll_io_bridge {
 
 struct dll_bridge {
   ADBAPIHANDLE (*AdbEnumInterfaces)(GUID, bool, bool, bool);
-  ADBAPIHANDLE (*AdbCreateInterfaceByName)(const wchar_t *);
+  ADBAPIHANDLE (*AdbCreateInterfaceByName)(const wchar_t *, const wchar_t *);
   ADBAPIHANDLE (*AdbCreateInterface)(GUID, unsigned short, unsigned short, unsigned char);
   bool (*AdbGetInterfaceName)(ADBAPIHANDLE, void *, unsigned long *, bool);
   bool (*AdbGetSerialNumber)(ADBAPIHANDLE, void *, unsigned long *, bool);

--- a/android-tools/adb-bin/transport.cpp
+++ b/android-tools/adb-bin/transport.cpp
@@ -402,6 +402,8 @@ oops:
     return NULL;
 }
 
+// TODO: BUG: The Peak on Windows rarely doesn't close the input thread.
+//   This causes the UI thread to hang on exit.
 void *input_thread(void *_t, struct dll_io_bridge * _io_bridge)
 {
     i_bridge = _io_bridge;

--- a/android-tools/adb-bin/transport.cpp
+++ b/android-tools/adb-bin/transport.cpp
@@ -30,9 +30,9 @@
 #include "array_lists.h"
 #include "threads.h"
 
-#define D_ D
-#undef D
-#define D printf
+//#define D_ D
+//#undef D
+//#define D printf
 
 static void transport_unref(atransport *t);
 
@@ -1216,5 +1216,5 @@ int check_data(apacket *p)
     }
 }
 
-#undef D
-#define D D_
+//#undef D
+//#define D D_

--- a/android-tools/adb-bin/transport.cpp
+++ b/android-tools/adb-bin/transport.cpp
@@ -435,7 +435,7 @@ void *input_thread(void *_t, struct dll_io_bridge * _io_bridge)
             }
         } else {
             if(active) {
-                D("%s: transport got packet, sending to remote\n", t->serial);
+                D("%s: transport got packet %d, sending to remote\n", t->serial, p->msg.command);
                 t->write_to_remote(p, t);
             } else {
                 D("%s: transport ignoring packet while offline\n", t->serial);
@@ -460,6 +460,7 @@ void *input_thread(void *_t, struct dll_io_bridge * _io_bridge)
     transport_unref(t);
 	D("Post-unref transport input-thread\n");
 #ifdef WIN32
+    D("Let device-loop close\n");
     notify_should_kill();
     set_io_pump_status(0);
 #endif

--- a/android-tools/adb-bin/transport.cpp
+++ b/android-tools/adb-bin/transport.cpp
@@ -30,9 +30,9 @@
 #include "array_lists.h"
 #include "threads.h"
 
-//#define D_ D
-//#undef D
-//#define D printf
+#define D_ D
+#undef D
+#define D printf
 
 static void transport_unref(atransport *t);
 
@@ -1213,5 +1213,5 @@ int check_data(apacket *p)
     }
 }
 
-//#undef D
-//#define D D_
+#undef D
+#define D D_

--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -288,7 +288,7 @@ usb_handle* do_usb_open(const wchar_t* interface_name) {
   ret->prev = ret;
 
   // Get dll_path and put it into a wchar_t
-  char * dll_path = "C:\\Users\\bkase\\Documents\\work\\r2d2b2g\\addon\\data\\win32\\adb\\AdbWinUsbApi.dll";
+  char * dll_path = (char *)MSG("winusbdll-path", NULL);
   long len = strlen(dll_path) + 1;
   wchar_t * dll_path_w = (wchar_t *)malloc(len * sizeof(wchar_t));
   mbstowcs(dll_path_w, dll_path, len);

--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -43,9 +43,9 @@
 #define AdbCloseHandle(...) (false)
 #endif
 
-#define D_ D
-#undef D
-#define D printf
+//#define D_ D
+//#undef D
+//#define D printf
 
 
 /** Structure usb_handle describes our connection to the usb device via
@@ -292,7 +292,7 @@ usb_handle* do_usb_open(const wchar_t* interface_name) {
   long len = strlen(dll_path) + 1;
   wchar_t * dll_path_w = (wchar_t *)malloc(len * sizeof(wchar_t));
   mbstowcs(dll_path_w, dll_path, len);
-  
+
   // Create interface.
   ret->adb_interface = bridge->AdbCreateInterfaceByName(interface_name, dll_path_w);
   free(dll_path_w);
@@ -418,7 +418,7 @@ int usb_read(usb_handle *handle, void* data, int len) {
 
       // loop until there is a byte
       int saved_errno = 0;
-      
+
       D("Pre read call\n");
       completed_handle = o_bridge->AdbReadEndpointAsync(handle->adb_read_pipe,
                                   (void*)data_,
@@ -441,7 +441,7 @@ int usb_read(usb_handle *handle, void* data, int len) {
           D("HasOvelappedIoComplated, errno: %d\n", saved_errno);
           return -1;
         }
-        
+
         if (should_kill) {
           return -1;
           // the input thread will notify_should_kill
@@ -601,7 +601,7 @@ void find_devices() {
   if (NULL == enum_handle)
     return;
 
-  while (bridge->AdbNextInterface(enum_handle, next_interface, &entry_buffer_size)) { 
+  while (bridge->AdbNextInterface(enum_handle, next_interface, &entry_buffer_size)) {
     D("Within the bridge->AdbNextInterface list\n");
     // TODO: FIXME - temp hack converting wchar_t into char.
     // It would be better to change AdbNextInterface so it will return
@@ -654,8 +654,8 @@ void find_devices() {
   }
 
   bridge->AdbCloseHandle(enum_handle);
-  
+
 }
 
-#undef D
-#define D D_
+//#undef D
+//#define D D_

--- a/android-tools/adb-bin/usb_windows.cpp
+++ b/android-tools/adb-bin/usb_windows.cpp
@@ -231,6 +231,11 @@ void should_kill_threads() {
   // wait for both the device loop's and the input_thread's death (if it exists)
   D("Waiting for %d notifications\n", 2 + is_io_pump_on - 1);
   while(should_kill < (2 + is_io_pump_on)) {
+    // TODO: HACK: For some reason Geeksphone Peak will not close its device
+    //   input thread unless there is a sleep here. (probably starvation)
+    //   I think the adb_cond_wait/adb_broadcast implementations don't work.
+    //   This should be removed when we patch adb_cond_wait/adb_broadcast.
+    adb_sleep_ms(1);
     // hang on a condition
     adb_cond_wait(&should_kill_cond, NULL);
   }

--- a/android-tools/adb-win-api/api/AdbWinApi.cpp
+++ b/android-tools/adb-win-api/api/AdbWinApi.cpp
@@ -106,7 +106,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE instance,
   // variable. We do that only once, on condition that this DLL is
   // being attached to the process and InstantiateWinUsbInterface
   // address has not been calculated yet.
-  // 
+  //
   // Do this lazily so we know the path to the DLL
   /*if (DLL_PROCESS_ATTACH == reason) {
     _AtlModule.AttachToAdbWinUsbApi();

--- a/android-tools/adb-win-api/api/adb_api.cpp
+++ b/android-tools/adb-win-api/api/adb_api.cpp
@@ -104,7 +104,8 @@ bool __cdecl AdbResetInterfaceEnum(ADBAPIHANDLE adb_handle) {
 }
 
 ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(
-    const wchar_t* interface_name) {
+    const wchar_t* interface_name,
+    const wchar_t* dll_path) {
   AdbInterfaceObject* obj = NULL;
   ADBAPIHANDLE ret = NULL;
 
@@ -114,6 +115,11 @@ ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(
       // We have legacy USB driver underneath us.
       obj = new AdbLegacyInterfaceObject(interface_name);
     } else {
+      // Try to load the InstantiateWinUsbInterface routine if necessary
+      if (NULL == InstantiateWinUsbInterface && NULL != dll_path) {
+        initWinUsbDll(dll_path);
+      }
+      
       // We have WinUsb driver underneath us. Make sure that AdbWinUsbApi.dll
       // is loaded and its InstantiateWinUsbInterface routine address has
       // been cached.
@@ -188,7 +194,7 @@ ADBAPIHANDLE __cdecl AdbCreateInterface(GUID class_id,
                       next_interface.device_name().c_str(),
                       match_len)) {
       // Found requested interface among active interfaces.
-      return AdbCreateInterfaceByName(next_interface.device_name().c_str());
+      return AdbCreateInterfaceByName(next_interface.device_name().c_str(), (wchar_t *)NULL);
     }
   }
 

--- a/android-tools/adb-win-api/api/adb_api.cpp
+++ b/android-tools/adb-win-api/api/adb_api.cpp
@@ -119,7 +119,7 @@ ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(
       if (NULL == InstantiateWinUsbInterface && NULL != dll_path) {
         initWinUsbDll(dll_path);
       }
-      
+
       // We have WinUsb driver underneath us. Make sure that AdbWinUsbApi.dll
       // is loaded and its InstantiateWinUsbInterface routine address has
       // been cached.

--- a/android-tools/adb-win-api/api/adb_api.h
+++ b/android-tools/adb-win-api/api/adb_api.h
@@ -268,7 +268,7 @@ ADBWIN_API bool __cdecl AdbResetInterfaceEnum(ADBAPIHANDLE adb_handle);
   @return Handle to the interface object or NULL on failure. If NULL is
           returned GetLastError() provides extended error information.
 */
-ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(const wchar_t* interface_name);
+ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(const wchar_t* interface_name, const wchar_t* dll_path);
 
 /** \brief Creates USB interface object based on vendor, product and
   interface IDs.

--- a/android-tools/adb-win-api/api/adb_api.h
+++ b/android-tools/adb-win-api/api/adb_api.h
@@ -291,7 +291,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterface(GUID class_id,
 
 /** \brief Gets interface name.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] buffer Buffer for the name. Can be NULL in which case
          buffer_char_size will contain number of characters required for
@@ -312,7 +312,7 @@ ADBWIN_API bool __cdecl AdbGetInterfaceName(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets serial number for interface's device.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] buffer Buffer for the serail number string. Can be NULL in which
          case buffer_char_size will contain number of characters required for
@@ -334,7 +334,7 @@ ADBWIN_API bool __cdecl AdbGetSerialNumber(ADBAPIHANDLE adb_interface,
 /** \brief Gets device descriptor for the USB device associated with
   the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          descriptor.
@@ -346,7 +346,7 @@ ADBWIN_API bool __cdecl AdbGetUsbDeviceDescriptor(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets descriptor for the selected USB device configuration.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          configuration descriptor.
@@ -359,7 +359,7 @@ ADBWIN_API bool __cdecl AdbGetUsbConfigurationDescriptor(
 
 /** \brief Gets descriptor for the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          configuration descriptor.
@@ -371,7 +371,7 @@ ADBWIN_API bool __cdecl AdbGetUsbInterfaceDescriptor(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets information about an endpoint on the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] endpoint_index Zero-based endpoint index. There are two
          shortcuts for this parameter: ADB_QUERY_BULK_WRITE_ENDPOINT_INDEX
@@ -388,7 +388,7 @@ ADBWIN_API bool __cdecl AdbGetEndpointInformation(ADBAPIHANDLE adb_interface,
 /** \brief Gets information about default bulk read endpoint on the given
   interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] info Upon successful completion will have endpoint information.
   @return true on success, false on failure. If false is returned
@@ -401,7 +401,7 @@ ADBWIN_API bool __cdecl AdbGetDefaultBulkReadEndpointInformation(
 /** \brief Gets information about default bulk write endpoint on the given
   interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] info Upon successful completion will have endpoint information.
   @return true on success, false on failure. If false is returned
@@ -414,7 +414,7 @@ ADBWIN_API bool __cdecl AdbGetDefaultBulkWriteEndpointInformation(
 /** \brief Opens an endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] endpoint_index Zero-based endpoint index. There are two
          shortcuts for this parameter: ADB_QUERY_BULK_WRITE_ENDPOINT_INDEX
@@ -437,7 +437,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbOpenEndpoint(ADBAPIHANDLE adb_interface,
 /** \brief Opens default bulk read endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] access_type Desired access type. In the current implementation
          this parameter has no effect on the way endpoint is opened. It's
@@ -456,7 +456,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbOpenDefaultBulkReadEndpoint(
 /** \brief Opens default bulk write endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] access_type Desired access type. In the current implementation
          this parameter has no effect on the way endpoint is opened. It's

--- a/android-tools/adb-win-api/api/adb_winusb_api.h
+++ b/android-tools/adb-win-api/api/adb_winusb_api.h
@@ -44,5 +44,7 @@
 */
 typedef class AdbInterfaceObject* \
     (__cdecl *PFN_INSTWINUSBINTERFACE)(const wchar_t*);
+    
+void initWinUsbDll(const wchar_t * dll_path);
 
 #endif  // ANDROID_USB_API_ADBWINUSBAPI_H__

--- a/android-tools/include/adb_api.h
+++ b/android-tools/include/adb_api.h
@@ -268,7 +268,7 @@ ADBWIN_API bool __cdecl AdbResetInterfaceEnum(ADBAPIHANDLE adb_handle);
   @return Handle to the interface object or NULL on failure. If NULL is
           returned GetLastError() provides extended error information.
 */
-ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(const wchar_t* interface_name);
+ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterfaceByName(const wchar_t* interface_name, const wchar_t* dll_path);
 
 /** \brief Creates USB interface object based on vendor, product and
   interface IDs.

--- a/android-tools/include/adb_api.h
+++ b/android-tools/include/adb_api.h
@@ -291,7 +291,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbCreateInterface(GUID class_id,
 
 /** \brief Gets interface name.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] buffer Buffer for the name. Can be NULL in which case
          buffer_char_size will contain number of characters required for
@@ -312,7 +312,7 @@ ADBWIN_API bool __cdecl AdbGetInterfaceName(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets serial number for interface's device.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] buffer Buffer for the serail number string. Can be NULL in which
          case buffer_char_size will contain number of characters required for
@@ -334,7 +334,7 @@ ADBWIN_API bool __cdecl AdbGetSerialNumber(ADBAPIHANDLE adb_interface,
 /** \brief Gets device descriptor for the USB device associated with
   the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          descriptor.
@@ -346,7 +346,7 @@ ADBWIN_API bool __cdecl AdbGetUsbDeviceDescriptor(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets descriptor for the selected USB device configuration.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          configuration descriptor.
@@ -359,7 +359,7 @@ ADBWIN_API bool __cdecl AdbGetUsbConfigurationDescriptor(
 
 /** \brief Gets descriptor for the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] desc Upon successful completion will have usb device
          configuration descriptor.
@@ -371,7 +371,7 @@ ADBWIN_API bool __cdecl AdbGetUsbInterfaceDescriptor(ADBAPIHANDLE adb_interface,
 
 /** \brief Gets information about an endpoint on the given interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] endpoint_index Zero-based endpoint index. There are two
          shortcuts for this parameter: ADB_QUERY_BULK_WRITE_ENDPOINT_INDEX
@@ -388,7 +388,7 @@ ADBWIN_API bool __cdecl AdbGetEndpointInformation(ADBAPIHANDLE adb_interface,
 /** \brief Gets information about default bulk read endpoint on the given
   interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] info Upon successful completion will have endpoint information.
   @return true on success, false on failure. If false is returned
@@ -401,7 +401,7 @@ ADBWIN_API bool __cdecl AdbGetDefaultBulkReadEndpointInformation(
 /** \brief Gets information about default bulk write endpoint on the given
   interface.
 
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[out] info Upon successful completion will have endpoint information.
   @return true on success, false on failure. If false is returned
@@ -414,7 +414,7 @@ ADBWIN_API bool __cdecl AdbGetDefaultBulkWriteEndpointInformation(
 /** \brief Opens an endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] endpoint_index Zero-based endpoint index. There are two
          shortcuts for this parameter: ADB_QUERY_BULK_WRITE_ENDPOINT_INDEX
@@ -437,7 +437,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbOpenEndpoint(ADBAPIHANDLE adb_interface,
 /** \brief Opens default bulk read endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] access_type Desired access type. In the current implementation
          this parameter has no effect on the way endpoint is opened. It's
@@ -456,7 +456,7 @@ ADBWIN_API ADBAPIHANDLE __cdecl AdbOpenDefaultBulkReadEndpoint(
 /** \brief Opens default bulk write endpoint on the given interface.
 
   Endpoints are always opened for overlapped I/O.
-  @param[in] adb_interface A handle to interface object created with 
+  @param[in] adb_interface A handle to interface object created with
          AdbCreateInterface call.
   @param[in] access_type Desired access type. In the current implementation
          this parameter has no effect on the way endpoint is opened. It's


### PR DESCRIPTION
AdbWinUsbApi.dll is required for the Peak to connect to ADB. This DLL was never loaded properly, now we pass the proper path to the dll all the way into AdbWinApi.dll so it can load the DLL properly.

I'm assuming that this patch will also make a lot of other untested devices work as well.

Rarely, on exit, the device input thread will not terminate for some reason if a Peak is plugged into a Windows machine. This causes the UI thread to hang indefinitely.
