### PR TITLE
Fix message callback index.

### DIFF
--- a/addon/lib/adb/evented-chrome-worker.js
+++ b/addon/lib/adb/evented-chrome-worker.js
@@ -152,7 +152,7 @@
         this.msgToCallbacksRespond[msg] = [];
       }
 
-      let idx = this.msgToCallbacksRespond[msg].push(cb);
+      let idx = this.msgToCallbacksRespond[msg].push(cb) - 1;
       return idx;
     },
 
@@ -162,7 +162,7 @@
         this.msgToCallbacksFree[msg] = [];
       }
 
-      let idx = this.msgToCallbacksFree[msg].push(cb);
+      let idx = this.msgToCallbacksFree[msg].push(cb) - 1;
       return idx;
     },
 
@@ -195,8 +195,8 @@
     },
 
     _callCbs: function _callCbs(cbs, data, andThenCb) {
-      for (let i = 0; i < cbs.length; i++) {
-        let res = cbs[i](data);
+      for (let key in cbs) {
+        let res = cbs[key](data);
         andThenCb(res);
       }
     }


### PR DESCRIPTION
The wrong index was being stored for the callbacks since push() returns the new length. Callbacks were still getting called since it loops over all the callbacks, but they weren't be freed correctly and once() callbacks could possibly be called multiple times.
