### PR TITLE
"firefoxos port" and "firefoxos start [port]" gcli commands

### DIFF
--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -177,6 +177,20 @@ Gcli.addCommand({
 });
 
 Gcli.addCommand({
+  name: "firefoxos debuggerport",
+  description: "Show the allocated remote debugger port",
+  returnType: 'string',
+  exec: function(args, context) {
+    if (Simulator.isRunning) {
+      return "Simulator debugger port: " +
+        Simulator.remoteSimulator.remoteDebuggerPort;
+    } else {
+      return "Simulator is not running.";
+    }
+  },
+});
+
+Gcli.addCommand({
   name: "firefoxos start",
   description: "Start Firefox OS Simulator (restarts if running)",
   params: [],

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -209,6 +209,30 @@ Gcli.addCommand({
 });
 
 Gcli.addCommand({
+  name: "firefoxos listen",
+  description: "Specify a remote debugger port to listen on",
+  params: [{
+    name: 'port',
+    type: 'number',
+    description: 'Set a specific remote debugger port'
+  }],
+  returnType: 'string',
+  exec: function(args, context) {
+    if (args.port) {
+      // TODO: port to #756 once ready
+      if (Simulator.isRunning && args.port != Simulator.remoteSimulator.remoteDebuggerPort) {
+        Simulator.remoteSimulator.startSecondaryListener(args.port);
+      } else {
+        Simulator.remoteSimulator.remoteDebuggerPort = args.port;
+        Simulator.run();
+      }
+    } else {
+      return "port arguments is mandatory";
+    }
+  },
+});
+
+Gcli.addCommand({
   name: "firefoxos stop",
   description: "Stop Firefox OS Simulator",
   params: [],

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -193,8 +193,16 @@ Gcli.addCommand({
 Gcli.addCommand({
   name: "firefoxos start",
   description: "Start Firefox OS Simulator (restarts if running)",
-  params: [],
+  params: [{
+    name: 'port',
+    type: 'number',
+    description: 'Set a specific remote debugger port'
+  }],
   exec: function(args, context) {
+    if (args.port) {
+      // TODO: port to #756 once ready
+      Simulator.remoteSimulator.remoteDebuggerPort = args.port;
+    }
     Simulator.run();
   },
 });

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -177,7 +177,7 @@ Gcli.addCommand({
 });
 
 Gcli.addCommand({
-  name: "firefoxos debuggerport",
+  name: "firefoxos port",
   description: "Show the allocated remote debugger port",
   returnType: 'string',
   exec: function(args, context) {

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -190,7 +190,9 @@ Gcli.addCommand({
     if (Simulator.isRunning) {
       return "Simulator is running, listening on port: " +
         Simulator.remoteSimulator.remoteDebuggerPort;
-    } else if (SimplePrefs.preferredSimulatorPort !== 0) {
+    } else if (SimplePrefs.preferredSimulatorPort && // NOTE: workaround hidden simple prefs
+                                                     // needed until we can use http://bugzil.la/768388
+               SimplePrefs.preferredSimulatorPort !== -1) {
       return "Simulator is not running. Preferred port: " +
         SimplePrefs.preferredSimulatorPort;
     } else {

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -184,11 +184,11 @@ Gcli.addCommand({
 
 Gcli.addCommand({
   name: "firefoxos port get",
-  description: "Show the allocated remote debugger port",
+  description: "Show the preferred remote debugger port",
   returnType: 'string',
   exec: function(args, context) {
     if (Simulator.isRunning) {
-      return "Simulator is running: Listening on port: " +
+      return "Simulator is running, listening on port: " +
         Simulator.remoteSimulator.remoteDebuggerPort;
     } else if (SimplePrefs.preferredSimulatorPort !== 0) {
       return "Simulator is not running. Preferred port: " +
@@ -212,7 +212,7 @@ Gcli.addCommand({
     if (args.port) {
       SimplePrefs.preferredSimulatorPort = args.port;
     } else {
-      return "port arguments is mandatory";
+      return "port argument is mandatory";
     }
   },
 });

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -18,6 +18,7 @@ const SStorage = require("simple-storage");
 const Gcli = require('gcli');
 const Simulator = require("simulator.js");
 const Prefs = require("preferences-service");
+const SimplePrefs = require("sdk/simple-prefs").prefs;
 
 require("marketplace-mod");
 
@@ -177,58 +178,58 @@ Gcli.addCommand({
 });
 
 Gcli.addCommand({
-  name: "firefoxos port",
+  name: 'firefoxos port',
+  description: 'Commands to control Firefox OS Simulator preferred Remote Debugger Port',
+});
+
+Gcli.addCommand({
+  name: "firefoxos port get",
   description: "Show the allocated remote debugger port",
   returnType: 'string',
   exec: function(args, context) {
     if (Simulator.isRunning) {
-      return "Simulator debugger port: " +
+      return "Simulator is running: Listening on port: " +
         Simulator.remoteSimulator.remoteDebuggerPort;
+    } else if (SimplePrefs.preferredSimulatorPort !== 0) {
+      return "Simulator is not running. Preferred port: " +
+        SimplePrefs.preferredSimulatorPort;
     } else {
-      return "Simulator is not running.";
+      return "Simulator is not running. No preferred port set.";
     }
+  },
+});
+
+Gcli.addCommand({
+  name: "firefoxos port set",
+  description: "Set a preferred Remote Debugger Port to listen on",
+  params: [{
+    name: 'port',
+    type: 'number',
+    description: 'Simulator preferred Remote Debugger Port'
+  }],
+  returnType: 'string',
+  exec: function(args, context) {
+    if (args.port) {
+      SimplePrefs.preferredSimulatorPort = args.port;
+    } else {
+      return "port arguments is mandatory";
+    }
+  },
+});
+
+Gcli.addCommand({
+  name: "firefoxos port reset",
+  description: "Reset preferred Remote Debugger Port to listen on",
+  exec: function(args, context) {
+    SimplePrefs.preferredSimulatorPort = 0;
   },
 });
 
 Gcli.addCommand({
   name: "firefoxos start",
-  description: "Start Firefox OS Simulator (restarts if running)",
-  params: [{
-    name: 'port',
-    type: 'number',
-    description: 'Set a specific remote debugger port',
-    defaultValue: null
-  }],
+  description: "Start Firefox OS Simulator",
   exec: function(args, context) {
-    if (args.port) {
-      // TODO: port to #756 once ready
-      Simulator.remoteSimulator.remoteDebuggerPort = args.port;
-    }
     Simulator.run();
-  },
-});
-
-Gcli.addCommand({
-  name: "firefoxos listen",
-  description: "Specify a remote debugger port to listen on",
-  params: [{
-    name: 'port',
-    type: 'number',
-    description: 'Set a specific remote debugger port'
-  }],
-  returnType: 'string',
-  exec: function(args, context) {
-    if (args.port) {
-      // TODO: port to #756 once ready
-      if (Simulator.isRunning && args.port != Simulator.remoteSimulator.remoteDebuggerPort) {
-        Simulator.remoteSimulator.startSecondaryListener(args.port);
-      } else {
-        Simulator.remoteSimulator.remoteDebuggerPort = args.port;
-        Simulator.run();
-      }
-    } else {
-      return "port arguments is mandatory";
-    }
   },
 });
 

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -196,7 +196,8 @@ Gcli.addCommand({
   params: [{
     name: 'port',
     type: 'number',
-    description: 'Set a specific remote debugger port'
+    description: 'Set a specific remote debugger port',
+    defaultValue: null
   }],
   exec: function(args, context) {
     if (args.port) {

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -221,7 +221,7 @@ Gcli.addCommand({
   name: "firefoxos port reset",
   description: "Reset preferred Remote Debugger Port to listen on",
   exec: function(args, context) {
-    SimplePrefs.preferredSimulatorPort = 0;
+    SimplePrefs.preferredSimulatorPort = -1;
   },
 });
 

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -391,6 +391,14 @@ const RemoteSimulatorClient = Class({
                                 onResponse);
   },
 
+  startSecondaryListener: function(port, onResponse) {
+    this._remote.client.request({ to: this._remote.simulator,
+                                  type: "startSecondaryListener",
+                                  port: port
+                                },
+                                onResponse);
+  },
+
   // send a ping request to the remote simulator actor
   ping: function(onResponse) {
     let remote = this._remote;

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
 'use strict';
@@ -80,7 +80,7 @@ const RemoteSimulatorClient = Class({
   },
 
   _hookInternalEvents: function () {
-    // on clientConnected, register an handler to close current connection 
+    // on clientConnected, register an handler to close current connection
     // on kill and send a "listTabs" debug protocol request, finally
     // emit a clientReady event on "listTabs" reply
     this.on("clientConnected", function (data) {
@@ -120,7 +120,7 @@ const RemoteSimulatorClient = Class({
         }).bind(this));
     });
 
-    // on clientClosed, untrack old remote target and emit 
+    // on clientClosed, untrack old remote target and emit
     // an high level "disconnected" event
     this.on("clientClosed", function () {
       console.debug("rsc.onClientClosed");
@@ -175,7 +175,7 @@ const RemoteSimulatorClient = Class({
           arguments: ["-e", 'tell application "' + path + '" to activate'],
         });
       }
-    });  
+    });
 
     let environment;
     if (Runtime.OS == "Linux") {
@@ -227,7 +227,7 @@ const RemoteSimulatorClient = Class({
         this.once("exit", onKilled);
       this.process.kill();
     }
-  },  
+  },
 
   // connect simulator using debugging protocol
   // NOTE: this control channel will be auto-created on every b2g instance run
@@ -444,7 +444,7 @@ const RemoteSimulatorClient = Class({
     let url = Self.data.url(executables[Runtime.OS]);
     let path = URL.toFilename(url);
 
-    let executable = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);    
+    let executable = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
     executable.initWithPath(path);
     let executableFilename = executables[Runtime.OS];
 
@@ -521,14 +521,10 @@ const RemoteSimulatorClient = Class({
       return port;
     }
 
-    if (SimplePrefs.preferredSimulatorPort !== 0) {
+    if (SimplePrefs.preferredSimulatorPort !== -1) {
       port = SimplePrefs.preferredSimulatorPort;
 
-      if (this._tryPort(port)) {
-        // NOTE: simulator will listen on the preferred port
-        this.remoteDebuggerPort = port;
-        return port;
-      } else {
+      if (! this._tryPort(port)) {
         // NOTE: simulator can't listen on preferred port
         // then find a port and warn the user
         port = this._findPort();
@@ -548,6 +544,7 @@ const RemoteSimulatorClient = Class({
       port = this._findPort();
     }
 
+    // NOTE: cache port selected until the next run
     this.remoteDebuggerPort = port;
 
     return port;

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -392,14 +392,6 @@ const RemoteSimulatorClient = Class({
                                 onResponse);
   },
 
-  startSecondaryListener: function(port, onResponse) {
-    this._remote.client.request({ to: this._remote.simulator,
-                                  type: "startSecondaryListener",
-                                  port: port
-                                },
-                                onResponse);
-  },
-
   // send a ping request to the remote simulator actor
   ping: function(onResponse) {
     let remote = this._remote;

--- a/addon/lib/remote-simulator-client.js
+++ b/addon/lib/remote-simulator-client.js
@@ -521,7 +521,9 @@ const RemoteSimulatorClient = Class({
       return port;
     }
 
-    if (SimplePrefs.preferredSimulatorPort !== -1) {
+    if (SimplePrefs.preferredSimulatorPort && // NOTE: workaround hidden simple prefs
+                                              // needed until we can use http://bugzil.la/768388
+        SimplePrefs.preferredSimulatorPort !== -1) {
       port = SimplePrefs.preferredSimulatorPort;
 
       if (! this._tryPort(port)) {

--- a/addon/package.json
+++ b/addon/package.json
@@ -30,12 +30,13 @@
   "permissions": {
     "private-browsing": true
   },
-  "preferences": [
+  "!preferences": [
     {
       "name": "preferredSimulatorPort",
       "title": "Preferred Simulator Port",
       "description": "Simulator Remote Debugger Server will listen on this TCP port or trying to allocate it dinamically ",
       "type": "integer",
+      "hidden": true,
       "value": 0
     }
   ],

--- a/addon/package.json
+++ b/addon/package.json
@@ -30,6 +30,15 @@
   "permissions": {
     "private-browsing": true
   },
+  "preferences": [
+    {
+      "name": "preferredSimulatorPort",
+      "title": "Preferred Simulator Port",
+      "description": "Simulator Remote Debugger Server will listen on this TCP port or trying to allocate it dinamically ",
+      "type": "integer",
+      "value": 0
+    }
+  ],
   "license": "MPL 2.0",
   "unpack": true,
   "dependencies": ["gcli",

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -360,6 +360,23 @@ SimulatorActor.prototype = {
     };
   },
 
+  onStartSecondaryListener: function (aRequest) {
+    this.debug("Simulator received a start secondary listener request");
+    let res = this.simulatorWindow.wrappedJSObject.DebuggerServer.openSecondaryListener(aRequest.port);
+
+    if (!res) {
+      return {
+        success: false,
+        message: "secondary listener not started"
+      };
+    }
+
+    return {
+      success: true,
+      message: "secondary listener started"
+    };
+  },
+
   get homescreenWindow() {
     var shellw = this.simulatorWindow.document.getElementById("homescreen").contentWindow;
     return shellw;
@@ -383,6 +400,7 @@ SimulatorActor.prototype.requestTypes = {
   "uninstallApp": SimulatorActor.prototype.onUninstallApp,
   "appNotFound": SimulatorActor.prototype.onAppNotFound,
   "showNotification": SimulatorActor.prototype.onShowNotification,
+  "startSecondaryListener": SimulatorActor.prototype.onStartSecondaryListener,
 };
 
 DebuggerServer.removeGlobalActor(SimulatorActor);

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -360,23 +360,6 @@ SimulatorActor.prototype = {
     };
   },
 
-  onStartSecondaryListener: function (aRequest) {
-    this.debug("Simulator received a start secondary listener request");
-    let res = this.simulatorWindow.wrappedJSObject.DebuggerServer.openSecondaryListener(aRequest.port);
-
-    if (!res) {
-      return {
-        success: false,
-        message: "secondary listener not started"
-      };
-    }
-
-    return {
-      success: true,
-      message: "secondary listener started"
-    };
-  },
-
   get homescreenWindow() {
     var shellw = this.simulatorWindow.document.getElementById("homescreen").contentWindow;
     return shellw;
@@ -400,7 +383,6 @@ SimulatorActor.prototype.requestTypes = {
   "uninstallApp": SimulatorActor.prototype.onUninstallApp,
   "appNotFound": SimulatorActor.prototype.onAppNotFound,
   "showNotification": SimulatorActor.prototype.onShowNotification,
-  "startSecondaryListener": SimulatorActor.prototype.onStartSecondaryListener,
 };
 
 DebuggerServer.removeGlobalActor(SimulatorActor);

--- a/prosthesis/content/patch-start-debugger.js
+++ b/prosthesis/content/patch-start-debugger.js
@@ -14,7 +14,32 @@
     // Register our copy of styleeditor until it gets uplifted to b2g18
     DebuggerServer.addActors('chrome://prosthesis/content/dbg-styleeditor-actors.js');
     DebuggerServer.addTabActor(DebuggerServer.StyleEditorActor, "styleEditorActor");
-  }
+  };
+
+  // NOTE: used by the startSecondaryListener simulator actor command
+  DebuggerServer.openSecondaryListener = function SimulatorOpenSecondaryListener(aPort) {
+    this._checkInit();
+
+    if (this._secondaryListener) {
+      return true;
+    }
+
+    try {
+      const CC = Components.Constructor;
+      const ServerSocket = CC(
+        '@mozilla.org/network/server-socket;1', 'nsIServerSocket', 'init');
+      let flags = Ci.nsIServerSocket.KeepWhenOffline | Ci.nsIServerSocket.LoopbackOnly;
+      let socket = new ServerSocket(aPort, flags, 4);
+      socket.asyncListen(this);
+      this._secondaryListener = socket;
+    } catch (e) {
+      debug("Could not start debugging listener on port " + aPort + ": " + e);
+      throw Cr.NS_ERROR_NOT_AVAILABLE;
+    }
+    this._socketConnections++;
+
+    return true;
+  };
 
   // allow remote debugger connection without any user confirmation
   RemoteDebugger.prompt = function() {

--- a/prosthesis/content/patch-start-debugger.js
+++ b/prosthesis/content/patch-start-debugger.js
@@ -16,31 +16,6 @@
     DebuggerServer.addTabActor(DebuggerServer.StyleEditorActor, "styleEditorActor");
   };
 
-  // NOTE: used by the startSecondaryListener simulator actor command
-  DebuggerServer.openSecondaryListener = function SimulatorOpenSecondaryListener(aPort) {
-    this._checkInit();
-
-    if (this._secondaryListener) {
-      return true;
-    }
-
-    try {
-      const CC = Components.Constructor;
-      const ServerSocket = CC(
-        '@mozilla.org/network/server-socket;1', 'nsIServerSocket', 'init');
-      let flags = Ci.nsIServerSocket.KeepWhenOffline | Ci.nsIServerSocket.LoopbackOnly;
-      let socket = new ServerSocket(aPort, flags, 4);
-      socket.asyncListen(this);
-      this._secondaryListener = socket;
-    } catch (e) {
-      debug("Could not start debugging listener on port " + aPort + ": " + e);
-      throw Cr.NS_ERROR_NOT_AVAILABLE;
-    }
-    this._socketConnections++;
-
-    return true;
-  };
-
   // allow remote debugger connection without any user confirmation
   RemoteDebugger.prompt = function() {
     this._promptDone = true;


### PR DESCRIPTION
simplify the detection of the debugger port dynamically allocated by the Simulator
(should fix #802)
