### PR TITLE
Refactor geolocation to prepare actor for uplifting

### DIFF
--- a/prosthesis/components/FakeGeolocationProvider.js
+++ b/prosthesis/components/FakeGeolocationProvider.js
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* The FakeGeolocationProvider relies on observing r2d2b2g:geolocation-update
+/* The FakeGeolocationProvider relies on observing r2d2b2g:update-geolocation
  * notifications from content/shell.js, when the user changes their custom
- * coordinates, AND from content/dbg-simulator-actors.js, when the user wants
+ * coordinates, AND from content/dbg-geolocation-actors.js, when the user wants
  * to use their current coordinates.  The current coordinates are never fetched
  * until the user has explicitly selected that they want to share them.
- * shell.js will send a r2d2b2g:geolocation-start notification that is observed
- * by dbg-simulator-actors.js.  dbg-simulator-actors.js uses "unsolicited"
- * events to addon/lib/remote-simulator-client.js to request the current
- * coordinates from the main Firefox process.  shell.js keeps track of the
- * latest custom coordinates to show the user when they reopen the geolocation
- * window, while FakeGeolocationProvider.js keeps track of the coordinates that
- * will be passed to any DOM calls. */
+ * shell.js will send a r2d2b2g:enable-real-geolocation notification that is
+ * observed by dbg-geolocation-actors.js.  dbg-geolocation-actors.js uses
+ * "unsolicited" events to addon/lib/remote-simulator-client.js to request the
+ * current coordinates from the main Firefox process.  shell.js keeps track of
+ * the latest custom coordinates to show the user when they reopen the
+ * geolocation window, while FakeGeolocationProvider.js keeps track of the
+ * coordinates that will be passed to any DOM calls. */
 
 const Ci = Components.interfaces;
 const Cc = Components.classes;
@@ -58,12 +58,12 @@ function FakeGeolocationProvider() {
   this.position = new FakeGeoPosition(37.78937, -122.38912);
   this.watcher = null;
 
-  Services.obs.addObserver((function onGeolocationUpdate(message) {
+  Services.obs.addObserver((function onUpdateGeolocation(message) {
     let { lat, lon } = message.wrappedJSObject;
     dump("FakeGeolocationProvider received update " + lat + "x" + lon + "\n");
     this.position = new FakeGeoPosition(lat, lon);
     this.update();
-  }).bind(this), "r2d2b2g:geolocation-update", false);
+  }).bind(this), "r2d2b2g:update-geolocation", false);
 }
 
 FakeGeolocationProvider.prototype = {

--- a/prosthesis/content/dbg-geolocation-actors.js
+++ b/prosthesis/content/dbg-geolocation-actors.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+/**
+  * Creates a GeolocationActor.
+  * Allows a Firefox OS device to accept fake geolocation data for use during
+  * debugging.
+  */
+let GeolocationActor = function GeolocationActor(aConnection) {
+  this.debug("Geolocation actor created for a new connection");
+
+  this._connection = aConnection;
+  this._listeners = {};
+};
+
+GeolocationActor.prototype = {
+  actorPrefix: "simulatorGeolocation",
+
+  disconnect: function() {
+    this.debug("Geolocation actor connection closed");
+  },
+
+  /**
+   * Dump a debug message to stdout.  This is defined as a method to avoid
+   * polluting the global namespace of the debugger server, and it always dumps
+   * because the Add-on SDK automatically determines whether to log the message.
+   */
+  debug: function debug() {
+    dump(Array.slice(arguments).join(" ") + "\n");
+  },
+
+  onUpdate: function (aRequest) {
+    this.debug("Simulator received a geolocation response, updating provider");
+    Services.obs.notifyObservers({
+      wrappedJSObject: {
+        lat: aRequest.message.lat,
+        lon: aRequest.message.lon,
+      }
+    }, "r2d2b2g:update-geolocation", null);
+
+    return {};
+  }
+};
+
+/**
+ * The request types this actor can handle.
+ */
+GeolocationActor.prototype.requestTypes = {
+  "update": GeolocationActor.prototype.onUpdate
+};
+
+DebuggerServer.removeGlobalActor(GeolocationActor);
+DebuggerServer.addGlobalActor(GeolocationActor, "simulatorGeolocationActor");

--- a/prosthesis/content/dbg-geolocation-ui-actors.js
+++ b/prosthesis/content/dbg-geolocation-ui-actors.js
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+/**
+  * Creates a GeolocationUIActor.
+  * Allows a Firefox OS device to accept fake geolocation data for use during
+  * debugging.
+  */
+let GeolocationUIActor = function GeolocationUIActor(aConnection) {
+  this.debug("Geolocation UI actor created for a new connection");
+
+  this._connection = aConnection;
+  this._listeners = {};
+
+  Services.obs.addObserver(this, "r2d2b2g:enable-real-geolocation", false);
+  Services.obs.addObserver(this, "r2d2b2g:disable-real-geolocation", false);
+};
+
+GeolocationUIActor.prototype = {
+  actorPrefix: "simulatorGeolocationUI",
+
+  observe: function(aSubject, aTopic, aData) {
+    switch(aTopic) {
+      case "r2d2b2g:enable-real-geolocation":
+        this.enableRealGeolocation();
+        break;
+      case "r2d2b2g:disable-real-geolocation":
+        this.disableRealGeolocation();
+        break;
+    }
+  },
+
+  enableRealGeolocation: function() {
+    this.debug("Simulator requesting to enable watching real geolocation");
+    this._connection.send({
+      from: this.actorID,
+      type: "enableRealGeolocation"
+    });
+  },
+
+  disableRealGeolocation: function() {
+    this.debug("Simulator requesting to disable watching real geolocation");
+    this._connection.send({
+      from: this.actorID,
+      type: "disableRealGeolocation"
+    });
+  },
+
+  disconnect: function() {
+    this.debug("Geolocation UI actor connection closed");
+  },
+
+  /**
+   * Dump a debug message to stdout.  This is defined as a method to avoid
+   * polluting the global namespace of the debugger server, and it always dumps
+   * because the Add-on SDK automatically determines whether to log the message.
+   */
+  debug: function debug() {
+    dump(Array.slice(arguments).join(" ") + "\n");
+  },
+
+  /**
+   * Actors are initialized lazily, so if they have any initialization work to
+   * perform (set up listeners / observers, etc.), then some message must be
+   * sent to trigger that process. The "attach" message exists solely for this
+   * purpose.
+   */
+  onAttach: function(aRequest) {
+    this.debug("Geolocation UI actor received an 'attach' command");
+
+    return {};
+  }
+};
+
+/**
+ * The request types this actor can handle.
+ */
+GeolocationUIActor.prototype.requestTypes = {
+  "attach": GeolocationUIActor.prototype.onAttach
+};
+
+DebuggerServer.removeGlobalActor(GeolocationUIActor);
+DebuggerServer.addGlobalActor(GeolocationUIActor, "simulatorGeolocationUIActor");

--- a/prosthesis/content/dbg-simulator-actors.js
+++ b/prosthesis/content/dbg-simulator-actors.js
@@ -18,8 +18,6 @@ let SimulatorActor = function SimulatorActor(aConnection) {
   this._listeners = {};
 
   Services.obs.addObserver(this, "r2d2b2g:app-update", false);
-  Services.obs.addObserver(this, "r2d2b2g:geolocation-start", false);
-  Services.obs.addObserver(this, "r2d2b2g:geolocation-stop", false);
 };
 
 SimulatorActor.prototype = {
@@ -29,12 +27,6 @@ SimulatorActor.prototype = {
     switch(aTopic) {
       case "r2d2b2g:app-update":
         this.appUpdateObserver(aSubject);
-        break;
-      case "r2d2b2g:geolocation-start":
-        this.geolocationStart();
-        break;
-      case "r2d2b2g:geolocation-stop":
-        this.geolocationStop();
         break;
     }
   },
@@ -46,22 +38,6 @@ SimulatorActor.prototype = {
       type: "appUpdateRequest",
       origin: message.wrappedJSObject.origin,
       appId: message.wrappedJSObject.appId
-    });
-  },
-
-  geolocationStart: function() {
-    this.debug("Simulator requesting to start watching geolocation");
-    this._connection.send({
-      from: this.actorID,
-      type: "geolocationStart"
-    });
-  },
-
-  geolocationStop: function() {
-    this.debug("Simulator requesting to stop watching geolocation");
-    this._connection.send({
-      from: this.actorID,
-      type: "geolocationStop"
     });
   },
 
@@ -384,21 +360,6 @@ SimulatorActor.prototype = {
     };
   },
 
-  onGeolocationUpdate: function (aRequest) {
-    this.debug("Simulator received a geolocation response, updating provider");
-    Services.obs.notifyObservers({
-      wrappedJSObject: {
-        lat: aRequest.message.lat,
-        lon: aRequest.message.lon,
-      }
-    }, "r2d2b2g:geolocation-update", null);
-
-    return {
-      message: "geolocationUpdate request received",
-      success: true
-    };
-  },
-
   get homescreenWindow() {
     var shellw = this.simulatorWindow.document.getElementById("homescreen").contentWindow;
     return shellw;
@@ -422,7 +383,6 @@ SimulatorActor.prototype.requestTypes = {
   "uninstallApp": SimulatorActor.prototype.onUninstallApp,
   "appNotFound": SimulatorActor.prototype.onAppNotFound,
   "showNotification": SimulatorActor.prototype.onShowNotification,
-  "geolocationUpdate": SimulatorActor.prototype.onGeolocationUpdate,
 };
 
 DebuggerServer.removeGlobalActor(SimulatorActor);

--- a/prosthesis/content/patch-start-debugger.js
+++ b/prosthesis/content/patch-start-debugger.js
@@ -1,5 +1,4 @@
-// patch startDebugger to add simulator-actors and pingback simulator manager
-// on ready.
+// patch startDebugger to add actors and pingback simulator manager on ready.
 {
   debug("patch RemoteDebugger.start");
 
@@ -8,6 +7,8 @@
   RemoteDebugger.start = function simulatorRemoteDebuggerStart() {
     presimulator_RemoteDebugger_start(); // call original RemoteDebugger.start
     DebuggerServer.addActors('chrome://prosthesis/content/dbg-simulator-actors.js');
+    DebuggerServer.addActors('chrome://prosthesis/content/dbg-geolocation-actors.js');
+    DebuggerServer.addActors('chrome://prosthesis/content/dbg-geolocation-ui-actors.js');
     // NOTE: add temporary simulatorWebAppsActor
     DebuggerServer.addActors('chrome://prosthesis/content/dbg-webapps-actors.js');
     // Register our copy of styleeditor until it gets uplifted to b2g18

--- a/prosthesis/content/shell.js
+++ b/prosthesis/content/shell.js
@@ -57,7 +57,8 @@ document.getElementById("rotateButton").addEventListener("click", function() {
 
         if (params.useCurrent && !useCurrent) {
           debug("Current coordinates requested in shell, notifying Simulator");
-          Services.obs.notifyObservers(null, "r2d2b2g:geolocation-start", null);
+          Services.obs.notifyObservers(null, "r2d2b2g:enable-real-geolocation",
+                                       null);
         } else if (!params.useCurrent) {
           debug("custom coordinates requested in shell");
 
@@ -66,7 +67,8 @@ document.getElementById("rotateButton").addEventListener("click", function() {
           // Firefox to stop watching geolocation.
           if (useCurrent) {
             debug("current coordinates previously requested");
-            Services.obs.notifyObservers(null, "r2d2b2g:geolocation-stop",
+            Services.obs.notifyObservers(null,
+                                         "r2d2b2g:disable-real-geolocation",
                                          null);
           }
 
@@ -81,7 +83,7 @@ document.getElementById("rotateButton").addEventListener("click", function() {
                 lat: latitude,
                 lon: longitude,
               }
-            }, "r2d2b2g:geolocation-update", null);
+            }, "r2d2b2g:update-geolocation", null);
           }
         }
         useCurrent = params.useCurrent;


### PR DESCRIPTION
I am working towards moving the geolocation simulating functionality up to m-c, so that it will already be on-device in the future.

In that vein, I've extracted several actors from the general purpose `dbg-simulator-actors` into `dbg-geolocation-actors` and `dbg-geolocation-ui-actors`.

`dbg-geolocation-actor` is what I would want to get on-device. `dbg-geolocation-ui-actors` is very much dependent on the simulator's UI flow for controlling the geolocation settings, and since that may change significantly with the App Manager, I will leave this here in the simulator add-on for now.

I will likely extend `dbg-geolocation-actor` before moving it on device (as part of issue #804 and perhaps others).
