### PR TITLE
GCLI Jetpack repo disappeared, point to new one. Fixes #810, #813.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = git://github.com/mykmelez/jetpack-subprocess.git
 [submodule "addon/packages/gcli"]
 	path = addon/packages/gcli
-	url = git://github.com/erikvold/gcli-jplib.git
+	url = git://github.com/jryans/gcli-jplib.git
 [submodule "addon/packages/jsonlint"]
 	path = addon/packages/jsonlint
 	url = git://github.com/rpl/jsonlint.git


### PR DESCRIPTION
As noticed in issues #810 and #813, Erik Vold's gcli-jplib repo seems to have been removed, which breaks the build for new contributors.

This updates the submodule URL to point at the new repo.
