### PR TITLE
FIX: copy gaia/profile-debug/user.js to addon/template/profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ profile:
 	rm -rf addon/template
 	mkdir -p addon/template
 	mv gaia/profile addon/template/
+	cp gaia/profile-debug/user.js addon/template/profile/
 	cp addon-sdk/app-extension/bootstrap.js addon/template/
 	cp addon-sdk/app-extension/install.rdf addon/template/
 	mkdir -p addon/template/profile/extensions


### PR DESCRIPTION
Gaia user preferences generated by "gaia/build/preferences.js" are now located on "gaia/profile-debug/user.js" and needs to be copied over "addon/template/profile/user.js" to activate custom desktop-helper preferences.

b2g-desktops doesn't enable dom.w3c_touch_events by default, and if the preference is not set to 1, "document.createEvent('touchevent')" raise a NotSupportedError:

```
console.error: fxos_1_2_simulator:
JavaScript error: chrome://desktop-helper.js/content/touch-events.js, line 167: 
NotSupportedError: Operation is not supported
```

Using "dom.w3c_touch_events.enabled=1" fix the exception and "chrome://desktop-helper.js/content/touch-events.js" emulation helper works again (e.g. the FirefoxOS statusbar can be dragged again).

Reported on:
- fxos_1_2_simulator, version: 6.0pre5dev.20130929
- [b2g-26.0a2 linux x86_64 2013-09-29-00-40-04](https://ftp.mozilla.org/pub/mozilla.org/b2g/nightly/2013-09-29-00-40-04-mozilla-aurora/b2g-26.0a2.multi.linux-x86_64.tar.bz2)

Tested on:
- Linux (Ubuntu 13.04)
- Firefox Nightly 27.0a1 (2013-09-29)
