### PR TITLE
Support Firefox 31+ in the 4.0 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# generated Gaia profile and other files the Add-on SDK needs to be in that dir
-addon/template
+# generated Gaia profile
+addon/template/profile
+addon/*.xpi
 
 # platform-specific directories containing B2G Desktop binaries
 addon/data/mac64/B2G.app

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = git://github.com/mykmelez/jetpack-subprocess.git
 [submodule "addon/packages/gcli"]
 	path = addon/packages/gcli
-	url = git://github.com/erikvold/gcli-jplib.git
+	url = git://github.com/jryans/gcli-jplib.git
 [submodule "addon/packages/jsonlint"]
 	path = addon/packages/jsonlint
 	url = git://github.com/rpl/jsonlint.git

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ build: profile b2g adb
 
 clean:
 	rm -rf addon/data/$(B2G_PLATFORM)
-	rm -rf addon/template
+	rm -rf addon/template/profile
 	rm -f gaia/build/custom-prefs.js
 	rm -f gaia/build/custom-settings.json
 	rm -f $(ADB_PACKAGE)
@@ -149,11 +149,8 @@ profile:
 	cd gaia/tools/extensions/desktop-helper/ && zip -r ../../../profile/extensions/desktop-helper\@gaiamobile.org.xpi *
 	cd gaia/tools/extensions/activities/ && zip -r ../../../profile/extensions/activities\@gaiamobile.org.xpi *
 	rm -rf gaia/profile/startupCache
-	rm -rf addon/template
-	mkdir -p addon/template
+	rm -rf addon/template/profile
 	mv gaia/profile addon/template/
-	cp addon-sdk/app-extension/bootstrap.js addon/template/
-	cp addon-sdk/app-extension/install.rdf addon/template/
 	mkdir -p addon/template/profile/extensions
 	cd prosthesis && zip -r b2g-prosthesis\@mozilla.org.xpi content components defaults locale modules chrome.manifest install.rdf
 	mv prosthesis/b2g-prosthesis@mozilla.org.xpi addon/template/profile/extensions

--- a/addon/data/content-script.js
+++ b/addon/data/content-script.js
@@ -7,11 +7,14 @@
 let contentWindow = document.defaultView;
 
 contentWindow.addEventListener("message", function(event) {
-  self.postMessage(event.data);
+  let message = event.data;
+  if (message.destination === "content") {
+    return;
+  }
+  self.postMessage(message);
 }, false);
 
 self.on("message", function(message) {
-  let event = document.createEvent("CustomEvent");
-  event.initCustomEvent("addon-message", true, true, message);
-  document.documentElement.dispatchEvent(event);
+  message.destination = "content";
+  contentWindow.postMessage(message, "*");
 });

--- a/addon/data/content/css/main.css
+++ b/addon/data/content/css/main.css
@@ -605,3 +605,7 @@ section header {
 .device-connected #sidebar .device-dependent {
     height: 50px;
 }
+
+.connect {
+    display: none;
+}

--- a/addon/data/content/index.html
+++ b/addon/data/content/index.html
@@ -31,8 +31,10 @@
                     <img src="device.svg" alt="Device"> Device connected.
                 </h5>
                 <div id="deprecation-message" class="deprecated" hidden="true">
-                    This add-on is incompatible with Firefox 26 and greater.
-                    Please use the App Manager with the new Simulator add-ons.<br/>
+                    This add-on only supports the included Firefox OS 1.1
+                    simulator and pushing apps to 1.1 devices.
+                    To work with newer Firefox OS simulators and devices, please
+                    use the App Manager.<br/>
                     <a href="https://developer.mozilla.org/docs/Mozilla/Firefox_OS/Using_the_App_Manager">More information</a>
                 </div>
             </header>

--- a/addon/data/content/js/main.js
+++ b/addon/data/content/js/main.js
@@ -41,65 +41,64 @@ var Simulator = {
       $("#form-add-app").get(0).reset();
     });
 
-    document.documentElement.addEventListener(
-      "addon-message",
-      function addonMessageListener(event) {
-        var message = event.detail;
-        if (!("name" in message)) {
-          return;
-        }
-        console.log('Addon-message: ' + message.name);
-        switch (message.name) {
-          case "deviceConnected":
-            Simulator.deviceConnected = message.value;
-            console.log("device " + (message.value ? "" : "dis") + "connected");
-            Simulator.updateDeviceView();
-            break;
-          case "isRunning":
-            $(Simulator.toggler).prop('indeterminate', false);
-            $(Simulator.toggler).prop('checked', message.isRunning);
-            if (message.isRunning) {
-              $("#open-connect-devtools").show().prop("disabled", false);
-            } else {
-              $("#open-connect-devtools").hide().prop("disabled", true);
-            }
-            break;
-          case "listTabs":
-            var datalist = $('#list-app-tabs').empty();
-            var tablist = $('#new-from-tab').empty();
-            tablist.append('<option selected>Select an open tab</option>');
-            for (var url in message.list) {
-              var el = $('<option>').prop('value', url).text(message.list[url]);
-              datalist.append(el);
-              tablist.append(el);
-            }
-            break;
-          case "validateUrl":
-            var set = $('#add-app-url').parents('form').removeClass('is-manifest');
-            $("#add-hosted-app").prop("disabled", !!message.err);
-            if (message.err) {
-              $('#new-from-manifest, #add-app-url').attr('data-valid', 'no');
-              $('#add-app-url').prop('title', message.err);
-            } else {
-              set.addClass('is-manifest');
-              $('#new-from-manifest, #add-app-url').attr('data-valid', 'yes');
-            }
-            break;
-          case "listApps":
-            AppList.update(message.list);
-            break;
-          case "updateReceiptStart":
-            $('li').filter(function() $(this).data('id') == message.id).
-                    addClass("updateReceipt");
-            break;
-          case "updateReceiptStop":
-            $('li').filter(function() $(this).data('id') == message.id).
-                    removeClass("updateReceipt");
-            break;
-        }
-      },
-      false
-    );
+    window.addEventListener("message", function(event) {
+      var message = event.data;
+      if (message.destination !== "content") {
+        return;
+      }
+      if (!("name" in message)) {
+        return;
+      }
+      console.log('Addon-message: ' + message.name);
+      switch (message.name) {
+        case "deviceConnected":
+          Simulator.deviceConnected = message.value;
+          console.log("device " + (message.value ? "" : "dis") + "connected");
+          Simulator.updateDeviceView();
+          break;
+        case "isRunning":
+          $(Simulator.toggler).prop('indeterminate', false);
+          $(Simulator.toggler).prop('checked', message.isRunning);
+          if (message.isRunning) {
+            $("#open-connect-devtools").show().prop("disabled", false);
+          } else {
+            $("#open-connect-devtools").hide().prop("disabled", true);
+          }
+          break;
+        case "listTabs":
+          var datalist = $('#list-app-tabs').empty();
+          var tablist = $('#new-from-tab').empty();
+          tablist.append('<option selected>Select an open tab</option>');
+          for (var url in message.list) {
+            var el = $('<option>').prop('value', url).text(message.list[url]);
+            datalist.append(el);
+            tablist.append(el);
+          }
+          break;
+        case "validateUrl":
+          var set = $('#add-app-url').parents('form').removeClass('is-manifest');
+          $("#add-hosted-app").prop("disabled", !!message.err);
+          if (message.err) {
+            $('#new-from-manifest, #add-app-url').attr('data-valid', 'no');
+            $('#add-app-url').prop('title', message.err);
+          } else {
+            set.addClass('is-manifest');
+            $('#new-from-manifest, #add-app-url').attr('data-valid', 'yes');
+          }
+          break;
+        case "listApps":
+          AppList.update(message.list);
+          break;
+        case "updateReceiptStart":
+          $('li').filter(function() $(this).data('id') == message.id).
+                  addClass("updateReceipt");
+          break;
+        case "updateReceiptStop":
+          $('li').filter(function() $(this).data('id') == message.id).
+                  removeClass("updateReceipt");
+          break;
+      }
+    });
 
     window.postMessage({ name: "getIsRunning" }, "*");
     window.postMessage({ name: "getDeviceConnected" }, "*");

--- a/addon/lib/debugger.js
+++ b/addon/lib/debugger.js
@@ -41,11 +41,7 @@ let Ci = components.interfaces;
 let Cu = components.utils;
 
 Cu.import("resource://gre/modules/Services.jsm");
-try {
-  Cu.import("resource://gre/modules/commonjs/promise/core.js");
-} catch (e) {
-  Cu.import("resource://gre/modules/commonjs/sdk/core/promise.js");
-}
+let { Promise: promise } = Cu.import("resource://gre/modules/Promise.jsm", {});
 Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 
 if (!COMMONJS) {
@@ -65,7 +61,7 @@ this.Debugger = {
     let transport = debuggerSocketConnect("localhost", aPort);
     client = new DebuggerClient(transport);
 
-    let deferred = Promise.defer();
+    let deferred = promise.defer();
 
     let connectionTimer = setTimeout(function () {
       let errorMsg = "Failed to connect to device: timeout";
@@ -92,7 +88,7 @@ this.Debugger = {
     dump("webappsRequest " + webappsActor + "\n");
     aData.to = webappsActor;
     dump("about to send " + JSON.stringify(aData, null, 2) + "\n");
-    let deferred = Promise.defer();
+    let deferred = promise.defer();
     client.request(aData,
       function onResponse(aResponse) {
       dump("response=" + JSON.stringify(aResponse, null, 2) + "\n");

--- a/addon/lib/simulator.js
+++ b/addon/lib/simulator.js
@@ -22,7 +22,7 @@ const RemoteSimulatorClient = require("remote-simulator-client");
 const xulapp = require("sdk/system/xul-app");
 const JsonLint = require("jsonlint/jsonlint");
 const ADB = require("adb");
-const Promise = require("sdk/core/promise");
+const promise = require("sdk/core/promise");
 const Runtime = require("runtime");
 const Validator = require("./validator");
 
@@ -1489,7 +1489,7 @@ let simulator = module.exports = {
   },
 
   connectToDevice: function() {
-    let deferred = Promise.defer();
+    let deferred = promise.defer();
 
     this.connectADBToDevice().
     then(this.connectDebuggerToDevice.bind(this)).
@@ -1508,7 +1508,7 @@ let simulator = module.exports = {
   },
 
   connectADBToDevice: function() {
-    let deferred = Promise.defer();
+    let deferred = promise.defer();
 
     if (adbReady) {
       deferred.resolve();
@@ -1526,7 +1526,7 @@ let simulator = module.exports = {
   },
 
   connectDebuggerToDevice: function connectDebuggerToDevice() {
-    let deferred = Promise.defer();
+    let deferred = promise.defer();
 
     if (debuggerReady) {
       deferred.resolve();

--- a/addon/template/bootstrap.js
+++ b/addon/template/bootstrap.js
@@ -1,0 +1,338 @@
+/* vim:set ts=2 sw=2 sts=2 expandtab */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @see http://mxr.mozilla.org/mozilla-central/source/js/src/xpconnect/loader/mozJSComponentLoader.cpp
+
+'use strict';
+
+// IMPORTANT: Avoid adding any initialization tasks here, if you need to do
+// something before add-on is loaded consider addon/runner module instead!
+
+const { classes: Cc, Constructor: CC, interfaces: Ci, utils: Cu,
+        results: Cr, manager: Cm } = Components;
+const ioService = Cc['@mozilla.org/network/io-service;1'].
+                  getService(Ci.nsIIOService);
+const resourceHandler = ioService.getProtocolHandler('resource').
+                        QueryInterface(Ci.nsIResProtocolHandler);
+const systemPrincipal = CC('@mozilla.org/systemprincipal;1', 'nsIPrincipal')();
+const scriptLoader = Cc['@mozilla.org/moz/jssubscript-loader;1'].
+                     getService(Ci.mozIJSSubScriptLoader);
+const prefService = Cc['@mozilla.org/preferences-service;1'].
+                    getService(Ci.nsIPrefService).
+                    QueryInterface(Ci.nsIPrefBranch);
+const appInfo = Cc["@mozilla.org/xre/app-info;1"].
+                getService(Ci.nsIXULAppInfo);
+const vc = Cc["@mozilla.org/xpcom/version-comparator;1"].
+           getService(Ci.nsIVersionComparator);
+
+
+const REASON = [ 'unknown', 'startup', 'shutdown', 'enable', 'disable',
+                 'install', 'uninstall', 'upgrade', 'downgrade' ];
+
+const bind = Function.call.bind(Function.bind);
+
+let loader = null;
+let unload = null;
+let cuddlefishSandbox = null;
+let nukeTimer = null;
+
+// Utility function that synchronously reads local resource from the given
+// `uri` and returns content string.
+function readURI(uri) {
+  let ioservice = Cc['@mozilla.org/network/io-service;1'].
+    getService(Ci.nsIIOService);
+  let channel = ioservice.newChannel(uri, 'UTF-8', null);
+  let stream = channel.open();
+
+  let cstream = Cc['@mozilla.org/intl/converter-input-stream;1'].
+    createInstance(Ci.nsIConverterInputStream);
+  cstream.init(stream, 'UTF-8', 0, 0);
+
+  let str = {};
+  let data = '';
+  let read = 0;
+  do {
+    read = cstream.readString(0xffffffff, str);
+    data += str.value;
+  } while (read != 0);
+
+  cstream.close();
+
+  return data;
+}
+
+// We don't do anything on install & uninstall yet, but in a future
+// we should allow add-ons to cleanup after uninstall.
+function install(data, reason) {}
+function uninstall(data, reason) {}
+
+function startup(data, reasonCode) {
+  try {
+    let reason = REASON[reasonCode];
+    // URI for the root of the XPI file.
+    // 'jar:' URI if the addon is packed, 'file:' URI otherwise.
+    // (Used by l10n module in order to fetch `locale` folder)
+    let rootURI = data.resourceURI.spec;
+
+    // TODO: Maybe we should perform read harness-options.json asynchronously,
+    // since we can't do anything until 'sessionstore-windows-restored' anyway.
+    let options = JSON.parse(readURI(rootURI + './harness-options.json'));
+
+    let id = options.jetpackID;
+    let name = options.name;
+
+    // Clean the metadata
+    options.metadata[name]['permissions'] = options.metadata[name]['permissions'] || {};
+
+    // freeze the permissionss
+    Object.freeze(options.metadata[name]['permissions']);
+    // freeze the metadata
+    Object.freeze(options.metadata[name]);
+
+    // Register a new resource 'domain' for this addon which is mapping to
+    // XPI's `resources` folder.
+    // Generate the domain name by using jetpack ID, which is the extension ID
+    // by stripping common characters that doesn't work as a domain name:
+    let uuidRe =
+      /^\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}$/;
+
+    let domain = id.
+      toLowerCase().
+      replace(/@/g, '-at-').
+      replace(/\./g, '-dot-').
+      replace(uuidRe, '$1');
+
+    let prefixURI = 'resource://' + domain + '/';
+    let resourcesURI = ioService.newURI(rootURI + '/resources/', null, null);
+    resourceHandler.setSubstitution(domain, resourcesURI);
+
+    // Create path to URLs mapping supported by loader.
+    let paths = {
+      // Relative modules resolve to add-on package lib
+      './': prefixURI + name + '/lib/',
+      './tests/': prefixURI + name + '/tests/',
+      '': 'resource://gre/modules/commonjs/'
+    };
+
+    // Maps addon lib and tests ressource folders for each package
+    paths = Object.keys(options.metadata).reduce(function(result, name) {
+      result[name + '/'] = prefixURI + name + '/lib/'
+      result[name + '/tests/'] = prefixURI + name + '/tests/'
+      return result;
+    }, paths);
+
+    // We need to map tests folder when we run sdk tests whose package name
+    // is stripped
+    if (name == 'addon-sdk')
+      paths['tests/'] = prefixURI + name + '/tests/';
+
+    let useBundledSDK = options['force-use-bundled-sdk'];
+    if (!useBundledSDK) {
+      try {
+        useBundledSDK = prefService.getBoolPref("extensions.addon-sdk.useBundledSDK");
+      }
+      catch (e) {
+        // Pref doesn't exist, allow using Firefox shipped SDK
+      }
+    }
+
+    // Starting with Firefox 21.0a1, we start using modules shipped into firefox
+    // Still allow using modules from the xpi if the manifest tell us to do so.
+    // And only try to look for sdk modules in xpi if the xpi actually ship them
+    if (options['is-sdk-bundled'] &&
+        (vc.compare(appInfo.version, '21.0a1') < 0 || useBundledSDK)) {
+      // Maps sdk module folders to their resource folder
+      paths[''] = prefixURI + 'addon-sdk/lib/';
+      // test.js is usually found in root commonjs or SDK_ROOT/lib/ folder,
+      // so that it isn't shipped in the xpi. Keep a copy of it in sdk/ folder
+      // until we no longer support SDK modules in XPI:
+      paths['test'] = prefixURI + 'addon-sdk/lib/sdk/test.js';
+    }
+
+    // Retrieve list of module folder overloads based on preferences in order to
+    // eventually used a local modules instead of files shipped into Firefox.
+    let branch = prefService.getBranch('extensions.modules.' + id + '.path');
+    paths = branch.getChildList('', {}).reduce(function (result, name) {
+      // Allows overloading of any sub folder by replacing . by / in pref name
+      let path = name.substr(1).split('.').join('/');
+      // Only accept overloading folder by ensuring always ending with `/`
+      if (path) path += '/';
+      let fileURI = branch.getCharPref(name);
+
+      // On mobile, file URI has to end with a `/` otherwise, setSubstitution
+      // takes the parent folder instead.
+      if (fileURI[fileURI.length-1] !== '/')
+        fileURI += '/';
+
+      // Maps the given file:// URI to a resource:// in order to avoid various
+      // failure that happens with file:// URI and be close to production env
+      let resourcesURI = ioService.newURI(fileURI, null, null);
+      let resName = 'extensions.modules.' + domain + '.commonjs.path' + name;
+      resourceHandler.setSubstitution(resName, resourcesURI);
+
+      result[path] = 'resource://' + resName + '/';
+      return result;
+    }, paths);
+
+    // Make version 2 of the manifest
+    let manifest = options.manifest;
+
+    // Import `cuddlefish.js` module using a Sandbox and bootstrap loader.
+    let cuddlefishPath = 'loader/cuddlefish.js';
+    let cuddlefishURI = 'resource://gre/modules/commonjs/sdk/' + cuddlefishPath;
+    if (paths['sdk/']) { // sdk folder has been overloaded
+                         // (from pref, or cuddlefish is still in the xpi)
+      cuddlefishURI = paths['sdk/'] + cuddlefishPath;
+    }
+    else if (paths['']) { // root modules folder has been overloaded
+      cuddlefishURI = paths[''] + 'sdk/' + cuddlefishPath;
+    }
+
+    cuddlefishSandbox = loadSandbox(cuddlefishURI);
+    let cuddlefish = cuddlefishSandbox.exports;
+
+    // Normalize `options.mainPath` so that it looks like one that will come
+    // in a new version of linker.
+    let main = options.mainPath;
+
+    unload = cuddlefish.unload;
+    loader = cuddlefish.Loader({
+      paths: paths,
+      // modules manifest.
+      manifest: manifest,
+
+      // Add-on ID used by different APIs as a unique identifier.
+      id: id,
+      // Add-on name.
+      name: name,
+      // Add-on version.
+      version: options.metadata[name].version,
+      // Add-on package descriptor.
+      metadata: options.metadata[name],
+      // Add-on load reason.
+      loadReason: reason,
+
+      prefixURI: prefixURI,
+      // Add-on URI.
+      rootURI: rootURI,
+      // options used by system module.
+      // File to write 'OK' or 'FAIL' (exit code emulation).
+      resultFile: options.resultFile,
+      // File to write stdout.
+      logFile: options.logFile,
+      // Arguments passed as --static-args
+      staticArgs: options.staticArgs,
+
+      // Arguments related to test runner.
+      modules: {
+        '@test/options': {
+          allTestModules: options.allTestModules,
+          iterations: options.iterations,
+          filter: options.filter,
+          profileMemory: options.profileMemory,
+          stopOnError: options.stopOnError,
+          verbose: options.verbose,
+          parseable: options.parseable,
+        }
+      }
+    });
+
+    let module = cuddlefish.Module('sdk/loader/cuddlefish', cuddlefishURI);
+    let require = cuddlefish.Require(loader, module);
+
+    require('sdk/addon/runner').startup(reason, {
+      loader: loader,
+      main: main,
+      prefsURI: rootURI + 'defaults/preferences/prefs.js'
+    });
+  } catch (error) {
+    dump('Bootstrap error: ' + error.message + '\n' +
+         (error.stack || error.fileName + ': ' + error.lineNumber) + '\n');
+    throw error;
+  }
+};
+
+function loadSandbox(uri) {
+  let proto = {
+    sandboxPrototype: {
+      loadSandbox: loadSandbox,
+      ChromeWorker: ChromeWorker
+    }
+  };
+  let sandbox = Cu.Sandbox(systemPrincipal, proto);
+  // Create a fake commonjs environnement just to enable loading loader.js
+  // correctly
+  sandbox.exports = {};
+  sandbox.module = { uri: uri, exports: sandbox.exports };
+  sandbox.require = function (id) {
+    if (id !== "chrome")
+      throw new Error("Bootstrap sandbox `require` method isn't implemented.");
+
+    return Object.freeze({ Cc: Cc, Ci: Ci, Cu: Cu, Cr: Cr, Cm: Cm,
+      CC: bind(CC, Components), components: Components,
+      ChromeWorker: ChromeWorker });
+  };
+  scriptLoader.loadSubScript(uri, sandbox, 'UTF-8');
+  return sandbox;
+}
+
+function unloadSandbox(sandbox) {
+  if ("nukeSandbox" in Cu)
+    Cu.nukeSandbox(sandbox);
+}
+
+function setTimeout(callback, delay) {
+  let timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+  timer.initWithCallback({ notify: callback }, delay,
+                         Ci.nsITimer.TYPE_ONE_SHOT);
+  return timer;
+}
+
+function shutdown(data, reasonCode) {
+  let reason = REASON[reasonCode];
+  if (loader) {
+    unload(loader, reason);
+    unload = null;
+
+    // Don't waste time cleaning up if the application is shutting down
+    if (reason != "shutdown") {
+      // Avoid leaking all modules when something goes wrong with one particular
+      // module. Do not clean it up immediatly in order to allow executing some
+      // actions on addon disabling.
+      // We need to keep a reference to the timer, otherwise it is collected
+      // and won't ever fire.
+      nukeTimer = setTimeout(nukeModules, 1000);
+    }
+  }
+};
+
+function nukeModules() {
+  nukeTimer = null;
+  // module objects store `exports` which comes from sandboxes
+  // We should avoid keeping link to these object to avoid leaking sandboxes
+  for (let key in loader.modules) {
+    delete loader.modules[key];
+  }
+  // Direct links to sandboxes should be removed too
+  for (let key in loader.sandboxes) {
+    let sandbox = loader.sandboxes[key];
+    delete loader.sandboxes[key];
+    // Bug 775067: From FF17 we can kill all CCW from a given sandbox
+    unloadSandbox(sandbox);
+  }
+  loader = null;
+
+  // both `toolkit/loader` and `system/xul-app` are loaded as JSM's via
+  // `cuddlefish.js`, and needs to be unloaded to avoid memory leaks, when
+  // the addon is unload.
+
+  unloadSandbox(cuddlefishSandbox.loaderSandbox);
+  unloadSandbox(cuddlefishSandbox.xulappSandbox);
+
+  // Bug 764840: We need to unload cuddlefish otherwise it will stay alive
+  // and keep a reference to this compartment.
+  unloadSandbox(cuddlefishSandbox);
+  cuddlefishSandbox = null;
+}

--- a/addon/template/install.rdf
+++ b/addon/template/install.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>xulapp@toolness.com</em:id>
+    <em:version>1.0</em:version>
+    <em:type>2</em:type>
+    <em:bootstrap>true</em:bootstrap>
+    <em:unpack>false</em:unpack>
+
+    <!-- Firefox -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>30.0</em:minVersion>
+        <em:maxVersion>31.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
+    <!-- Front End MetaData -->
+    <em:name>Test App</em:name>
+    <em:description>Harness for tests.</em:description>
+    <em:creator>Mozilla Corporation</em:creator>
+    <em:homepageURL></em:homepageURL>
+    <em:optionsType></em:optionsType>
+    <em:updateURL></em:updateURL>
+  </Description>
+</RDF>


### PR DESCRIPTION
This updates the 4.0 branch to support Firefox 31+.

Mostly just promise updates as we had to do in other addons a while back.

However I also got error when trying to send custom events to the simulator dashboard page, so I just hacked that up to use `postMessage`. It's enough to get it working at least.

It's possible I've now broken the addon for pre-30 Firefox (that's the earliest I tested). Should I update the `minVersion`?
